### PR TITLE
docs: add comprehensive docstrings

### DIFF
--- a/lampkitctl/cli.py
+++ b/lampkitctl/cli.py
@@ -12,7 +12,21 @@ from . import db_ops, system_ops, utils, wp_ops
 @click.option("--verbose", is_flag=True, help="Enable verbose logging")
 @click.pass_context
 def cli(ctx: click.Context, dry_run: bool, verbose: bool) -> None:
-    """LAMP environment management tool."""
+    """LAMP environment management tool.
+
+    Args:
+        ctx (click.Context): Click context carrying shared state.
+        dry_run (bool): When ``True`` commands are logged but not executed.
+        verbose (bool): Enable verbose logging output.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> from click.testing import CliRunner
+        >>> runner = CliRunner()
+        >>> runner.invoke(cli, ["--dry-run", "version"])
+    """
     utils.setup_logging()
     if verbose:
         import logging
@@ -25,7 +39,19 @@ def cli(ctx: click.Context, dry_run: bool, verbose: bool) -> None:
 @cli.command("install-lamp")
 @click.pass_context
 def install_lamp(ctx: click.Context) -> None:
-    """Verify and install LAMP services."""
+    """Verify and install LAMP services.
+
+    Args:
+        ctx (click.Context): Click context carrying shared state.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> from click.testing import CliRunner
+        >>> runner = CliRunner()
+        >>> runner.invoke(cli, ["--dry-run", "install-lamp"])
+    """
     services = ["apache2", "mysql", "php"]
     dry_run = ctx.obj["dry_run"]
     for srv in services:
@@ -53,7 +79,24 @@ def create_site(
     db_password: str,
     wordpress: bool,
 ) -> None:
-    """Create a new site with Apache and MySQL."""
+    """Create a new site with Apache and MySQL.
+
+    Args:
+        ctx (click.Context): Click context carrying shared state.
+        domain (str): Domain name for the new site.
+        doc_root (str): Document root directory for the site.
+        db_name (str): Name of the MySQL database to create.
+        db_user (str): MySQL user with access to the database.
+        db_password (str): Password for ``db_user``.
+        wordpress (bool): If ``True`` install WordPress into the site.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> runner = CliRunner()
+        >>> runner.invoke(cli, ["--dry-run", "create-site", "example.com", "--doc-root=/var/www/example", "--db-name=db", "--db-user=user", "--db-password", "pw"])
+    """
     dry_run = ctx.obj["dry_run"]
     system_ops.create_web_directory(doc_root, dry_run=dry_run)
     system_ops.create_virtualhost(domain, doc_root, dry_run=dry_run)
@@ -75,7 +118,22 @@ def create_site(
 def uninstall_site(
     ctx: click.Context, domain: str, doc_root: str, db_name: str, db_user: str
 ) -> None:
-    """Remove a site and all related resources."""
+    """Remove a site and all related resources.
+
+    Args:
+        ctx (click.Context): Click context carrying shared state.
+        domain (str): Domain name of the site to remove.
+        doc_root (str): Document root path of the site.
+        db_name (str): Name of the database to drop.
+        db_user (str): Database user to remove.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> runner = CliRunner()
+        >>> runner.invoke(cli, ["--dry-run", "uninstall-site", "example.com", "--doc-root=/var/www/example", "--db-name=db", "--db-user=user"])
+    """
     dry_run = ctx.obj["dry_run"]
     if not utils.prompt_confirm(f"Remove site {domain}?", default=False):
         click.echo("Aborted")
@@ -88,7 +146,15 @@ def uninstall_site(
 
 @cli.command("list-sites")
 def list_sites() -> None:
-    """List configured Apache virtual hosts."""
+    """List configured Apache virtual hosts.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> runner = CliRunner()
+        >>> runner.invoke(cli, ["list-sites"])
+    """
     for site in system_ops.list_sites():
         click.echo(f"{site['domain']} -> {site['doc_root']}")
 
@@ -97,7 +163,19 @@ def list_sites() -> None:
 @click.argument("doc_root")
 @click.pass_context
 def wp_permissions(ctx: click.Context, doc_root: str) -> None:
-    """Set secure WordPress permissions."""
+    """Set secure WordPress permissions.
+
+    Args:
+        ctx (click.Context): Click context carrying shared state.
+        doc_root (str): Path to the WordPress installation.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> runner = CliRunner()
+        >>> runner.invoke(cli, ["--dry-run", "wp-permissions", "/var/www/site"])
+    """
     dry_run = ctx.obj["dry_run"]
     wp_ops.set_permissions(doc_root, dry_run=dry_run)
 
@@ -106,7 +184,19 @@ def wp_permissions(ctx: click.Context, doc_root: str) -> None:
 @click.argument("domain")
 @click.pass_context
 def generate_ssl(ctx: click.Context, domain: str) -> None:
-    """Generate an SSL certificate using certbot."""
+    """Generate an SSL certificate using certbot.
+
+    Args:
+        ctx (click.Context): Click context carrying shared state.
+        domain (str): Domain name for the certificate.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> runner = CliRunner()
+        >>> runner.invoke(cli, ["--dry-run", "generate-ssl", "example.com"])
+    """
     dry_run = ctx.obj["dry_run"]
     utils.run_command([
         "certbot",
@@ -118,9 +208,25 @@ def generate_ssl(ctx: click.Context, domain: str) -> None:
 
 @cli.command("version")
 def version_cmd() -> None:
-    """Show version."""
+    """Show version information.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> runner = CliRunner()
+        >>> runner.invoke(cli, ["version"])
+    """
     click.echo(__version__)
 
 
 def main() -> None:
+    """Entry point for executing the CLI directly.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> main()
+    """
     cli()

--- a/lampkitctl/db_ops.py
+++ b/lampkitctl/db_ops.py
@@ -18,7 +18,33 @@ def create_database_and_user(
     root_password: Optional[str] = None,
     dry_run: bool = False,
 ) -> None:
-    """Create a database and user with full privileges."""
+    """Create a MySQL database and associated user.
+
+    This function executes a series of SQL commands to create a database
+    if it does not already exist, create a user and grant that user full
+    privileges on the new database.
+
+    Args:
+        db_name (str): Name of the database to create.
+        user (str): Username for the new database user.
+        password (str): Password for the new user.
+        root_user (str, optional): MySQL root username used to execute the
+            SQL commands. Defaults to "root".
+        root_password (Optional[str], optional): Password for ``root_user``.
+            If provided, it is passed to the MySQL client. Defaults to ``None``.
+        dry_run (bool, optional): If ``True`` the command is logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        subprocess.CalledProcessError: If the underlying command fails and
+            ``dry_run`` is ``False``.
+
+    Example:
+        >>> create_database_and_user("blog", "blog_user", "s3cr3t", dry_run=True)
+    """
     sql = (
         f"CREATE DATABASE IF NOT EXISTS `{db_name}`;"
         f" CREATE USER IF NOT EXISTS '{user}'@'localhost' IDENTIFIED BY '{password}';"
@@ -43,7 +69,31 @@ def drop_database_and_user(
     root_password: Optional[str] = None,
     dry_run: bool = False,
 ) -> None:
-    """Drop database and user."""
+    """Remove a MySQL database and its user.
+
+    The database is dropped if it exists and the associated user is removed
+    along with its privileges.
+
+    Args:
+        db_name (str): Name of the database to drop.
+        user (str): Username to remove.
+        root_user (str, optional): MySQL root username used to execute the
+            SQL commands. Defaults to "root".
+        root_password (Optional[str], optional): Password for ``root_user``.
+            If provided, it is passed to the MySQL client. Defaults to ``None``.
+        dry_run (bool, optional): If ``True`` the command is logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        subprocess.CalledProcessError: If the underlying command fails and
+            ``dry_run`` is ``False``.
+
+    Example:
+        >>> drop_database_and_user("blog", "blog_user", dry_run=True)
+    """
     sql = (
         f"DROP DATABASE IF EXISTS `{db_name}`;"
         f" DROP USER IF EXISTS '{user}'@'localhost';"

--- a/lampkitctl/system_ops.py
+++ b/lampkitctl/system_ops.py
@@ -13,24 +13,93 @@ logger = logging.getLogger(__name__)
 
 
 def check_service(service: str) -> bool:
-    """Return True if the given service is installed."""
+    """Check whether a system service is installed.
+
+    Args:
+        service (str): Name of the service executable to search for.
+
+    Returns:
+        bool: ``True`` if the service is available in the ``PATH``;
+            otherwise ``False``.
+
+    Example:
+        >>> check_service("apache2")
+        True
+    """
     return shutil.which(service) is not None
 
 
 def install_service(service: str, dry_run: bool = False) -> None:
-    """Install a system service using apt-get."""
+    """Install a system service using ``apt-get``.
+
+    Args:
+        service (str): Name of the package to install.
+        dry_run (bool, optional): If ``True`` the command is logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        subprocess.CalledProcessError: If the installation command fails and
+            ``dry_run`` is ``False``.
+
+    Example:
+        >>> install_service("apache2", dry_run=True)
+    """
     cmd = ["apt-get", "install", "-y", service]
     run_command(["apt-get", "update"], dry_run)
     run_command(cmd, dry_run)
 
 
 def create_web_directory(path: str, dry_run: bool = False) -> None:
-    """Create the web directory for the site."""
+    """Create the document root for a website.
+
+    Args:
+        path (str): Directory path to create.
+        dry_run (bool, optional): If ``True`` the command is logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        subprocess.CalledProcessError: If the directory creation fails and
+            ``dry_run`` is ``False``.
+
+    Example:
+        >>> create_web_directory("/var/www/example", dry_run=True)
+    """
     run_command(["mkdir", "-p", path], dry_run)
 
 
-def create_virtualhost(domain: str, doc_root: str, sites_available: str = "/etc/apache2/sites-available", dry_run: bool = False) -> Path:
-    """Create an Apache virtualhost configuration file."""
+def create_virtualhost(
+    domain: str,
+    doc_root: str,
+    sites_available: str = "/etc/apache2/sites-available",
+    dry_run: bool = False,
+) -> Path:
+    """Create an Apache virtual host configuration file.
+
+    Args:
+        domain (str): Domain name served by the virtual host.
+        doc_root (str): Path to the site document root.
+        sites_available (str, optional): Directory where configuration files
+            are stored. Defaults to ``"/etc/apache2/sites-available"``.
+        dry_run (bool, optional): If ``True`` the command is logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        Path: Path to the generated configuration file.
+
+    Raises:
+        OSError: If the configuration file cannot be written and ``dry_run``
+            is ``False``.
+
+    Example:
+        >>> create_virtualhost("example.com", "/var/www/example", dry_run=True)
+        PosixPath('/etc/apache2/sites-available/example.com.conf')
+    """
     config = f"""
 <VirtualHost *:80>
     ServerName {domain}
@@ -52,13 +121,48 @@ def create_virtualhost(domain: str, doc_root: str, sites_available: str = "/etc/
 
 
 def enable_site(domain: str, dry_run: bool = False) -> None:
-    """Enable an Apache site."""
+    """Enable an Apache site and reload the server.
+
+    Args:
+        domain (str): Domain name of the site to enable.
+        dry_run (bool, optional): If ``True`` the command is logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        subprocess.CalledProcessError: If a command fails and ``dry_run`` is
+            ``False``.
+
+    Example:
+        >>> enable_site("example.com", dry_run=True)
+    """
     run_command(["a2ensite", domain], dry_run)
     run_command(["systemctl", "reload", "apache2"], dry_run)
 
 
 def add_host_entry(domain: str, ip: str = "127.0.0.1", hosts_file: str = "/etc/hosts", dry_run: bool = False) -> None:
-    """Add an entry to /etc/hosts."""
+    """Append a host entry to the ``/etc/hosts`` file.
+
+    Args:
+        domain (str): Hostname to associate with the IP address.
+        ip (str, optional): IP address to map to ``domain``. Defaults to
+            ``"127.0.0.1"``.
+        hosts_file (str, optional): Path to the hosts file. Defaults to
+            ``"/etc/hosts"``.
+        dry_run (bool, optional): If ``True`` the change is logged but not
+            written. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        OSError: If the file cannot be written and ``dry_run`` is ``False``.
+
+    Example:
+        >>> add_host_entry("example.com", hosts_file="/tmp/hosts", dry_run=True)
+    """
     entry = f"{ip} {domain}\n"
     if dry_run:
         logger.info("add_host_entry", extra={"entry": entry.strip()})
@@ -68,7 +172,21 @@ def add_host_entry(domain: str, ip: str = "127.0.0.1", hosts_file: str = "/etc/h
 
 
 def list_sites(sites_available: str = "/etc/apache2/sites-available") -> List[dict]:
-    """List configured Apache sites."""
+    """List configured Apache virtual hosts.
+
+    Args:
+        sites_available (str, optional): Directory containing Apache
+            configuration files. Defaults to
+            ``"/etc/apache2/sites-available"``.
+
+    Returns:
+        List[dict]: A list of dictionaries with ``domain`` and ``doc_root``
+        keys describing each virtual host.
+
+    Example:
+        >>> list_sites("/etc/apache2/sites-available")
+        [{'domain': 'example.com', 'doc_root': '/var/www/example'}]
+    """
     results: List[dict] = []
     for conf_file in Path(sites_available).glob("*.conf"):
         domain = conf_file.stem
@@ -84,8 +202,30 @@ def list_sites(sites_available: str = "/etc/apache2/sites-available") -> List[di
     return results
 
 
-def remove_virtualhost(domain: str, sites_available: str = "/etc/apache2/sites-available", dry_run: bool = False) -> None:
-    """Remove Apache virtualhost configuration."""
+def remove_virtualhost(
+    domain: str,
+    sites_available: str = "/etc/apache2/sites-available",
+    dry_run: bool = False,
+) -> None:
+    """Delete an Apache virtual host configuration file.
+
+    Args:
+        domain (str): Domain name whose configuration should be removed.
+        sites_available (str, optional): Directory containing Apache
+            configuration files. Defaults to
+            ``"/etc/apache2/sites-available"``.
+        dry_run (bool, optional): If ``True`` the action is logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        OSError: If the file cannot be removed and ``dry_run`` is ``False``.
+
+    Example:
+        >>> remove_virtualhost("example.com", dry_run=True)
+    """
     conf_path = Path(sites_available) / f"{domain}.conf"
     if dry_run:
         logger.info("remove_virtualhost", extra={"path": str(conf_path)})
@@ -97,12 +237,46 @@ def remove_virtualhost(domain: str, sites_available: str = "/etc/apache2/sites-a
 
 
 def remove_web_directory(path: str, dry_run: bool = False) -> None:
-    """Remove the web directory."""
+    """Remove the document root directory for a site.
+
+    Args:
+        path (str): Path to the directory to remove.
+        dry_run (bool, optional): If ``True`` the command is logged but not
+            executed. Defaults to ``False".
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        subprocess.CalledProcessError: If removal fails and ``dry_run`` is
+            ``False``.
+
+    Example:
+        >>> remove_web_directory("/var/www/example", dry_run=True)
+    """
     run_command(["rm", "-rf", path], dry_run)
 
 
 def remove_host_entry(domain: str, hosts_file: str = "/etc/hosts", dry_run: bool = False) -> None:
-    """Remove entry from /etc/hosts."""
+    """Remove a host entry from ``/etc/hosts``.
+
+    Args:
+        domain (str): Hostname to remove.
+        hosts_file (str, optional): Path to the hosts file. Defaults to
+            ``"/etc/hosts"``.
+        dry_run (bool, optional): If ``True`` the change is logged but not
+            written. Defaults to ``False".
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        OSError: If the hosts file cannot be modified and ``dry_run`` is
+            ``False".
+
+    Example:
+        >>> remove_host_entry("example.com", hosts_file="/tmp/hosts", dry_run=True)
+    """
     if dry_run:
         logger.info("remove_host_entry", extra={"domain": domain})
         return

--- a/lampkitctl/utils.py
+++ b/lampkitctl/utils.py
@@ -8,22 +8,75 @@ from typing import Iterable, List, Optional
 
 
 class JsonFormatter(logging.Formatter):
-    """Simple JSON log formatter."""
+    """Format log records as JSON strings.
+
+    This formatter converts :class:`logging.LogRecord` instances into JSON
+    objects, including extra attributes attached to the record.
+    """
 
     def format(self, record: logging.LogRecord) -> str:
+        """Return the log record as a JSON string.
+
+        Args:
+            record (logging.LogRecord): Record to format.
+
+        Returns:
+            str: JSON representation of the log record.
+
+        Example:
+            >>> logger = logging.getLogger(__name__)
+            >>> logger.addHandler(logging.StreamHandler())
+            >>> logger.handlers[0].setFormatter(JsonFormatter())
+            >>> logger.info("hello")
+            {"level": "INFO", ...}
+        """
         data = {
             "level": record.levelname,
             "message": record.getMessage(),
             "time": self.formatTime(record, self.datefmt),
         }
         for key, value in getattr(record, "__dict__", {}).items():
-            if key not in {"levelname", "msg", "args", "name", "levelno", "pathname", "filename", "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName", "created", "msecs", "relativeCreated", "thread", "threadName", "processName", "process"}:
+            if key not in {
+                "levelname",
+                "msg",
+                "args",
+                "name",
+                "levelno",
+                "pathname",
+                "filename",
+                "module",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "lineno",
+                "funcName",
+                "created",
+                "msecs",
+                "relativeCreated",
+                "thread",
+                "threadName",
+                "processName",
+                "process",
+            }:
                 data[key] = value
         return json.dumps(data)
 
 
 def setup_logging(level: int = logging.INFO) -> None:
-    """Configure root logger with JSON formatter."""
+    """Configure the root logger with a JSON formatter.
+
+    Args:
+        level (int, optional): Logging level for the root logger. Defaults to
+            :data:`logging.INFO`.
+
+    Returns:
+        None: This function does not return a value.
+
+    Example:
+        >>> setup_logging()
+        >>> logging.getLogger(__name__).info("hi")
+        {"level": "INFO", ...}
+    """
     handler = logging.StreamHandler()
     handler.setFormatter(JsonFormatter())
     logging.basicConfig(level=level, handlers=[handler], force=True)
@@ -39,16 +92,26 @@ def run_command(
     log_cmd: Optional[Iterable[str]] = None,
     **kwargs,
 ) -> subprocess.CompletedProcess:
-    """Execute a system command with logging and optional dry-run.
+    """Execute a system command with logging and optional dry run.
 
     Args:
-        cmd: Command and arguments to execute.
-        dry_run: If ``True`` the command is logged but not executed.
-        check: If ``True`` raise :class:`subprocess.CalledProcessError` on error.
-        log_cmd: Optional command representation to log instead of ``cmd``.
+        cmd (List[str]): Command and arguments to execute.
+        dry_run (bool, optional): If ``True`` the command is logged but not
+            executed. Defaults to ``False``.
+        check (bool, optional): If ``True`` raise
+            :class:`subprocess.CalledProcessError` on non-zero exit. Defaults
+            to ``True``.
+        log_cmd (Optional[Iterable[str]], optional): Alternate command to log
+            instead of ``cmd``. Defaults to ``None``.
+        **kwargs: Additional arguments passed to :func:`subprocess.run`.
 
     Returns:
-        :class:`subprocess.CompletedProcess` representing the result.
+        subprocess.CompletedProcess: Result of the executed command or a dummy
+            instance when ``dry_run`` is ``True``.
+
+    Example:
+        >>> run_command(["echo", "hi"], dry_run=True)
+        CompletedProcess(args=['echo', 'hi'], returncode=0)
     """
     logger.info("run_command", extra={"cmd": list(log_cmd or cmd), "dry_run": dry_run})
     if dry_run:
@@ -57,7 +120,21 @@ def run_command(
 
 
 def prompt_confirm(message: str, default: bool = False) -> bool:
-    """Prompt the user for confirmation."""
+    """Prompt the user for a yes/no confirmation.
+
+    Args:
+        message (str): Message to display to the user.
+        default (bool, optional): Default response if the user presses enter
+            without typing anything. Defaults to ``False``.
+
+    Returns:
+        bool: ``True`` if the user confirms, ``False`` otherwise.
+
+    Example:
+        >>> # Assuming user types 'y'
+        >>> prompt_confirm('Proceed?')
+        True
+    """
     prompt = " [Y/n]: " if default else " [y/N]: "
     while True:
         resp = input(message + prompt).strip().lower()

--- a/lampkitctl/wp_ops.py
+++ b/lampkitctl/wp_ops.py
@@ -13,7 +13,24 @@ WORDPRESS_URL = "https://wordpress.org/latest.tar.gz"
 
 
 def download_wordpress(target_dir: str, dry_run: bool = False) -> None:
-    """Download and extract WordPress into target directory."""
+    """Download and extract the latest WordPress package.
+
+    Args:
+        target_dir (str): Directory where WordPress should be downloaded and
+            extracted.
+        dry_run (bool, optional): If ``True`` the commands are logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        subprocess.CalledProcessError: If a command fails and ``dry_run`` is
+            ``False``.
+
+    Example:
+        >>> download_wordpress("/var/www", dry_run=True)
+    """
     tar_path = str(Path(target_dir) / "wordpress.tar.gz")
     run_command(["wget", "-q", WORDPRESS_URL, "-O", tar_path], dry_run)
     run_command(["tar", "-xzf", tar_path, "-C", target_dir], dry_run)
@@ -26,7 +43,26 @@ def install_wordpress(
     db_password: str,
     dry_run: bool = False,
 ) -> None:
-    """Install WordPress into ``doc_root``."""
+    """Install WordPress into ``doc_root`` and configure the database.
+
+    Args:
+        doc_root (str): Target directory for the WordPress installation.
+        db_name (str): Name of the MySQL database.
+        db_user (str): Database username.
+        db_password (str): Database user password.
+        dry_run (bool, optional): If ``True`` the commands are logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        OSError: If configuration files cannot be read or written and
+            ``dry_run`` is ``False``.
+
+    Example:
+        >>> install_wordpress("/var/www", "db", "user", "pw", dry_run=True)
+    """
     download_wordpress(doc_root, dry_run)
     sample = Path(doc_root) / "wordpress" / "wp-config-sample.php"
     config = Path(doc_root) / "wordpress" / "wp-config.php"
@@ -43,7 +79,25 @@ def install_wordpress(
 
 
 def set_permissions(doc_root: str, owner: str = "www-data", dry_run: bool = False) -> None:
-    """Set secure permissions for a WordPress installation."""
+    """Set secure file permissions for a WordPress installation.
+
+    Args:
+        doc_root (str): Path to the WordPress installation.
+        owner (str, optional): Owner and group for the files. Defaults to
+            ``"www-data"``.
+        dry_run (bool, optional): If ``True`` the commands are logged but not
+            executed. Defaults to ``False``.
+
+    Returns:
+        None: This function does not return a value.
+
+    Raises:
+        subprocess.CalledProcessError: If a command fails and ``dry_run`` is
+            ``False``.
+
+    Example:
+        >>> set_permissions("/var/www/site", dry_run=True)
+    """
     path = Path(doc_root)
     run_command(["chown", "-R", f"{owner}:{owner}", str(path)], dry_run)
     run_command(["find", str(path), "-type", "d", "-exec", "chmod", "755", "{}", ";"], dry_run)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,19 +2,35 @@ from click.testing import CliRunner
 from lampkitctl import cli
 
 
-def test_cli_install_lamp(monkeypatch):
+def test_cli_install_lamp(monkeypatch) -> None:
+    """Validate installation command sequence for LAMP services.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     calls = []
     monkeypatch.setattr(cli.system_ops, "check_service", lambda s: False)
-    monkeypatch.setattr(cli.system_ops, "install_service", lambda s, dry_run: calls.append(s))
+    monkeypatch.setattr(
+        cli.system_ops, "install_service", lambda s, dry_run: calls.append(s)
+    )
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["--dry-run", "install-lamp"])
     assert result.exit_code == 0
     assert calls == ["apache2", "mysql", "php"]
 
 
-def test_cli_create_site(monkeypatch):
-    monkeypatch.setattr(cli.system_ops, "create_web_directory", lambda *a, **k: None)
-    monkeypatch.setattr(cli.system_ops, "create_virtualhost", lambda *a, **k: None)
+def test_cli_create_site(monkeypatch) -> None:
+    """Ensure the CLI orchestrates site creation steps.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
+    monkeypatch.setattr(
+        cli.system_ops, "create_web_directory", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        cli.system_ops, "create_virtualhost", lambda *a, **k: None
+    )
     monkeypatch.setattr(cli.system_ops, "enable_site", lambda *a, **k: None)
     monkeypatch.setattr(cli.system_ops, "add_host_entry", lambda *a, **k: None)
     monkeypatch.setattr(cli.db_ops, "create_database_and_user", lambda *a, **k: None)
@@ -36,9 +52,16 @@ def test_cli_create_site(monkeypatch):
     assert result.exit_code == 0
 
 
-def test_cli_uninstall_site(monkeypatch):
+def test_cli_uninstall_site(monkeypatch) -> None:
+    """Validate removal of a site through the CLI.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     monkeypatch.setattr(cli.utils, "prompt_confirm", lambda *a, **k: True)
-    monkeypatch.setattr(cli.system_ops, "remove_virtualhost", lambda *a, **k: None)
+    monkeypatch.setattr(
+        cli.system_ops, "remove_virtualhost", lambda *a, **k: None
+    )
     monkeypatch.setattr(cli.system_ops, "remove_host_entry", lambda *a, **k: None)
     monkeypatch.setattr(cli.system_ops, "remove_web_directory", lambda *a, **k: None)
     monkeypatch.setattr(cli.db_ops, "drop_database_and_user", lambda *a, **k: None)
@@ -57,8 +80,15 @@ def test_cli_uninstall_site(monkeypatch):
     assert result.exit_code == 0
 
 
-def test_cli_list_sites(monkeypatch):
-    monkeypatch.setattr(cli.system_ops, "list_sites", lambda: [{"domain": "a", "doc_root": "/var/www/a"}])
+def test_cli_list_sites(monkeypatch) -> None:
+    """Check that configured sites are listed correctly.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
+    monkeypatch.setattr(
+        cli.system_ops, "list_sites", lambda: [{"domain": "a", "doc_root": "/var/www/a"}]
+    )
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["list-sites"])
     assert "a -> /var/www/a" in result.output

--- a/tests/test_db_ops.py
+++ b/tests/test_db_ops.py
@@ -1,7 +1,12 @@
 from lampkitctl import db_ops
 
 
-def test_create_database_and_user(monkeypatch):
+def test_create_database_and_user(monkeypatch) -> None:
+    """Ensure database and user creation calls the correct SQL.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     recorded = {}
 
     def fake_run(cmd, dry_run, log_cmd=None):
@@ -16,7 +21,12 @@ def test_create_database_and_user(monkeypatch):
     assert "-p******" in recorded["log_cmd"]
 
 
-def test_drop_database_and_user(monkeypatch):
+def test_drop_database_and_user(monkeypatch) -> None:
+    """Verify database and user removal executes SQL commands.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     called = {}
 
     def fake_run(cmd, dry_run, log_cmd=None):

--- a/tests/test_system_ops.py
+++ b/tests/test_system_ops.py
@@ -2,7 +2,12 @@ import logging
 from lampkitctl import system_ops
 
 
-def test_create_virtualhost(tmp_path):
+def test_create_virtualhost(tmp_path) -> None:
+    """Ensure virtual host configuration files are created.
+
+    Args:
+        tmp_path (pathlib.Path): Temporary directory provided by pytest.
+    """
     conf_dir = tmp_path / "sites"
     conf_dir.mkdir()
     conf_path = system_ops.create_virtualhost(
@@ -11,27 +16,47 @@ def test_create_virtualhost(tmp_path):
     assert conf_path.exists()
 
 
-def test_list_sites(tmp_path):
+def test_list_sites(tmp_path) -> None:
+    """Verify detection of existing virtual host configurations.
+
+    Args:
+        tmp_path (pathlib.Path): Temporary directory provided by pytest.
+    """
     conf = tmp_path / "example.com.conf"
     conf.write_text("DocumentRoot /var/www/example")
     sites = system_ops.list_sites(str(tmp_path))
     assert sites[0]["domain"] == "example.com"
 
 
-def test_remove_virtualhost_dry_run(caplog):
+def test_remove_virtualhost_dry_run(caplog) -> None:
+    """Check that removal is logged during a dry run.
+
+    Args:
+        caplog (pytest.LogCaptureFixture): Fixture to capture log records.
+    """
     caplog.set_level(logging.INFO)
     system_ops.remove_virtualhost("nosite", sites_available="/tmp", dry_run=True)
     assert "remove_virtualhost" in caplog.text
 
 
-def test_install_service(monkeypatch):
+def test_install_service(monkeypatch) -> None:
+    """Validate system service installation command.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     calls = []
     monkeypatch.setattr(system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
     system_ops.install_service("apache2", dry_run=True)
     assert calls[1] == ["apt-get", "install", "-y", "apache2"]
 
 
-def test_add_and_remove_host_entry(tmp_path):
+def test_add_and_remove_host_entry(tmp_path) -> None:
+    """Ensure host entries can be added and removed.
+
+    Args:
+        tmp_path (pathlib.Path): Temporary directory provided by pytest.
+    """
     hosts = tmp_path / "hosts"
     system_ops.add_host_entry("example.com", hosts_file=str(hosts))
     assert "example.com" in hosts.read_text()
@@ -39,14 +64,25 @@ def test_add_and_remove_host_entry(tmp_path):
     assert "example.com" not in hosts.read_text()
 
 
-def test_enable_site(monkeypatch):
+def test_enable_site(monkeypatch) -> None:
+    """Verify enabling a site invokes the correct command.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     calls = []
     monkeypatch.setattr(system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
     system_ops.enable_site("example.com", dry_run=True)
     assert calls[0][0] == "a2ensite"
 
 
-def test_create_web_directory(monkeypatch, tmp_path):
+def test_create_web_directory(monkeypatch, tmp_path) -> None:
+    """Ensure web directories are created as expected.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+        tmp_path (pathlib.Path): Temporary directory provided by pytest.
+    """
     calls = []
     monkeypatch.setattr(system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
     system_ops.create_web_directory(str(tmp_path / "web"), dry_run=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,12 @@ import subprocess
 from lampkitctl import utils
 
 
-def test_run_command_dry_run(monkeypatch):
+def test_run_command_dry_run(monkeypatch) -> None:
+    """Ensure dry-run mode does not execute the command.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     called = False
 
     def fake_run(cmd, check, text):
@@ -16,7 +21,12 @@ def test_run_command_dry_run(monkeypatch):
     assert not called
 
 
-def test_run_command_executes(monkeypatch):
+def test_run_command_executes(monkeypatch) -> None:
+    """Verify that the command executes when not in dry-run mode.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     recorded = {}
 
     def fake_run(cmd, check, text):
@@ -29,23 +39,39 @@ def test_run_command_executes(monkeypatch):
     assert result.returncode == 0
 
 
-def test_prompt_confirm_yes(monkeypatch):
+def test_prompt_confirm_yes(monkeypatch) -> None:
+    """Confirm that affirmative input returns ``True``.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching builtins.
+    """
     monkeypatch.setattr("builtins.input", lambda _: "y")
     assert utils.prompt_confirm("?", default=False)
 
 
-def test_prompt_confirm_default(monkeypatch):
+def test_prompt_confirm_default(monkeypatch) -> None:
+    """Ensure default value is returned when input is empty.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching builtins.
+    """
     monkeypatch.setattr("builtins.input", lambda _: "")
     assert utils.prompt_confirm("?", default=True)
 
 
-def test_run_command_log_cmd(caplog):
+def test_run_command_log_cmd(caplog) -> None:
+    """Verify that an alternative command representation is logged.
+
+    Args:
+        caplog (pytest.LogCaptureFixture): Fixture to capture log records.
+    """
     caplog.set_level(logging.INFO)
     utils.run_command(["echo", "secret"], dry_run=True, log_cmd=["echo", "***"])
     assert caplog.records[0].cmd == ["echo", "***"]
 
 
-def test_setup_logging():
+def test_setup_logging() -> None:
+    """Check that logging is configured with at least one handler."""
     utils.setup_logging()
     logger = logging.getLogger()
     assert logger.handlers

--- a/tests/test_wp_ops.py
+++ b/tests/test_wp_ops.py
@@ -2,7 +2,12 @@ import logging
 from lampkitctl import wp_ops
 
 
-def test_set_permissions(monkeypatch):
+def test_set_permissions(monkeypatch) -> None:
+    """Ensure file permissions are set via three commands.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     calls = []
 
     def fake_run(cmd, dry_run):
@@ -13,7 +18,12 @@ def test_set_permissions(monkeypatch):
     assert len(calls) == 3
 
 
-def test_install_wordpress_dry_run(caplog):
+def test_install_wordpress_dry_run(caplog) -> None:
+    """Check that WordPress installation logs configuration in dry run.
+
+    Args:
+        caplog (pytest.LogCaptureFixture): Fixture to capture log records.
+    """
     caplog.set_level(logging.INFO)
     wp_ops.install_wordpress(
         "/tmp", "db", "user", "pw", dry_run=True
@@ -21,7 +31,12 @@ def test_install_wordpress_dry_run(caplog):
     assert "configure_wp" in caplog.text
 
 
-def test_download_wordpress(monkeypatch):
+def test_download_wordpress(monkeypatch) -> None:
+    """Verify the download command is executed.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
+    """
     calls = []
 
     def fake_run(cmd, dry_run):


### PR DESCRIPTION
## Summary
- document database operations and MySQL helpers
- add detailed docstrings for system, WordPress, and CLI utilities
- clarify test behavior with descriptive docstrings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c90b270cc8322814ffb466616e069