### PR TITLE
feat: add interactive menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ lampkitctl
 
 > La CLI globale sarà disponibile dopo aver configurato `setup.py` con l’entry point.
 
+### Interactive menu
+
+È disponibile un menu testuale interattivo che replica la UX della versione Bash. Per avviarlo:
+
+```bash
+lampkitctl menu
+```
+
+Il menu accetta le stesse opzioni globali, ad esempio:
+
+```bash
+lampkitctl menu --dry-run
+```
+
+Per un'esperienza migliorata è consigliata l'installazione opzionale della libreria [InquirerPy](https://github.com/kazhala/InquirerPy). In assenza della libreria, il menu utilizza un semplice fallback basato su input standard.
+
 Il presente progetto è un rifaccimento in python, e poi arricchito di nuove funzionalità, del seguente script in bash:
 
 ```bash

--- a/lampkitctl/cli.py
+++ b/lampkitctl/cli.py
@@ -206,6 +206,20 @@ def generate_ssl(ctx: click.Context, domain: str) -> None:
     ], dry_run)
 
 
+@cli.command("menu")
+@click.pass_context
+def menu_cmd(ctx: click.Context) -> None:
+    """Launch the interactive text-based menu.
+
+    Args:
+        ctx (click.Context): Click context carrying shared state.
+    """
+    from . import menu as menu_module
+
+    dry_run = ctx.obj["dry_run"]
+    menu_module.run_menu(dry_run=dry_run)
+
+
 @cli.command("version")
 def version_cmd() -> None:
     """Show version information.

--- a/lampkitctl/menu.py
+++ b/lampkitctl/menu.py
@@ -1,0 +1,319 @@
+"""Interactive text-based menu for lampkitctl."""
+from __future__ import annotations
+
+import getpass
+import logging
+import re
+from typing import Iterable, List, Optional
+
+from . import db_ops, system_ops, utils, wp_ops
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    from InquirerPy import inquirer
+except Exception:  # pragma: no cover - handled gracefully
+    inquirer = None
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+def validate_domain(domain: str) -> str:
+    """Validate a domain name.
+
+    Args:
+        domain: Domain string to validate.
+
+    Returns:
+        The original domain if valid.
+
+    Raises:
+        ValueError: If the domain does not match the expected format.
+    """
+    pattern = re.compile(
+        r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*\.[A-Za-z]{2,63}$"
+    )
+    if not pattern.match(domain):
+        raise ValueError("Invalid domain name")
+    return domain
+
+
+def validate_db_identifier(name: str) -> str:
+    """Validate MySQL identifier (database or user name).
+
+    Args:
+        name: Identifier to validate.
+
+    Returns:
+        The original name if valid.
+
+    Raises:
+        ValueError: If ``name`` contains invalid characters.
+    """
+    if not re.match(r"^[A-Za-z0-9_]+$", name):
+        raise ValueError("Invalid database identifier")
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Core actions (testable)
+# ---------------------------------------------------------------------------
+
+def install_lamp(dry_run: bool = False) -> None:
+    """Install required LAMP components if missing.
+
+    Args:
+        dry_run: When ``True`` log actions without executing.
+    """
+    services = ["apache2", "mysql", "php"]
+    for srv in services:
+        if system_ops.check_service(srv):
+            logger.info("service_present", extra={"service": srv})
+        else:
+            logger.info("install_service", extra={"service": srv})
+            system_ops.install_service(srv, dry_run=dry_run)
+
+
+def create_site(
+    domain: str,
+    doc_root: str,
+    db_name: str,
+    db_user: str,
+    db_password: str,
+    wordpress: bool,
+    dry_run: bool = False,
+) -> None:
+    """Create a site with Apache, MySQL and optional WordPress.
+
+    Args:
+        domain: Domain for the new site.
+        doc_root: Document root directory.
+        db_name: Name of the MySQL database.
+        db_user: MySQL username.
+        db_password: MySQL password (masked in logs).
+        wordpress: If ``True`` install WordPress.
+        dry_run: Log actions without executing.
+    """
+    logger.info(
+        "create_site",
+        extra={
+            "domain": domain,
+            "doc_root": doc_root,
+            "db_name": db_name,
+            "db_user": db_user,
+            "wordpress": wordpress,
+            "dry_run": dry_run,
+        },
+    )
+    system_ops.create_web_directory(doc_root, dry_run=dry_run)
+    system_ops.create_virtualhost(domain, doc_root, dry_run=dry_run)
+    system_ops.enable_site(domain, dry_run=dry_run)
+    system_ops.add_host_entry(domain, dry_run=dry_run)
+    db_ops.create_database_and_user(db_name, db_user, db_password, dry_run=dry_run)
+    if wordpress:
+        wp_ops.install_wordpress(doc_root, db_name, db_user, db_password, dry_run=dry_run)
+
+
+def uninstall_site(
+    domain: str,
+    doc_root: str,
+    db_name: str,
+    db_user: str,
+    remove_db: bool,
+    dry_run: bool = False,
+) -> None:
+    """Remove an existing site.
+
+    Args:
+        domain: Domain of the site to remove.
+        doc_root: Document root path.
+        db_name: Database name.
+        db_user: Database user.
+        remove_db: If ``True`` drop database and user.
+        dry_run: Log actions without executing.
+    """
+    logger.info("uninstall_site", extra={"domain": domain, "dry_run": dry_run})
+    system_ops.remove_virtualhost(domain, dry_run=dry_run)
+    system_ops.remove_host_entry(domain, dry_run=dry_run)
+    system_ops.remove_web_directory(doc_root, dry_run=dry_run)
+    if remove_db:
+        db_ops.drop_database_and_user(db_name, db_user, dry_run=dry_run)
+
+
+def set_wp_permissions(doc_root: str, dry_run: bool = False) -> None:
+    """Set secure permissions for a WordPress installation.
+
+    Args:
+        doc_root: Path to the WordPress installation.
+        dry_run: Log actions without executing.
+    """
+    logger.info("set_wp_permissions", extra={"doc_root": doc_root, "dry_run": dry_run})
+    wp_ops.set_permissions(doc_root, dry_run=dry_run)
+
+
+def generate_ssl(domain: str, dry_run: bool = False) -> None:
+    """Generate an SSL certificate using certbot.
+
+    Args:
+        domain: Domain for the certificate.
+        dry_run: Log actions without executing.
+    """
+    logger.info("generate_ssl", extra={"domain": domain, "dry_run": dry_run})
+    utils.run_command(["certbot", "--apache", "-d", domain], dry_run)
+
+
+def list_installed_sites() -> List[dict]:
+    """Return installed sites from Apache configuration."""
+    return system_ops.list_sites()
+
+
+# ---------------------------------------------------------------------------
+# Prompt helpers
+# ---------------------------------------------------------------------------
+
+def _select(message: str, choices: Iterable[str]) -> str:
+    if inquirer:  # pragma: no cover - optional path
+        return inquirer.select(message=message, choices=list(choices)).execute()
+    while True:
+        print(message)
+        choices_list = list(choices)
+        for idx, choice in enumerate(choices_list, 1):
+            print(f"{idx}) {choice}")
+        resp = input("Select: ").strip()
+        if resp.isdigit() and 1 <= int(resp) <= len(choices_list):
+            return choices_list[int(resp) - 1]
+
+
+def _text(message: str, default: Optional[str] = None) -> str:
+    if inquirer:  # pragma: no cover
+        return inquirer.text(message=message, default=default).execute()
+    prompt = f"{message}"
+    if default:
+        prompt += f" [{default}]"
+    prompt += ": "
+    resp = input(prompt).strip()
+    return resp or (default or "")
+
+
+def _password(message: str) -> str:
+    if inquirer:  # pragma: no cover
+        return inquirer.secret(message=message).execute()
+    return getpass.getpass(message + ": ")
+
+
+def _confirm(message: str, default: bool = False) -> bool:
+    if inquirer:  # pragma: no cover
+        return inquirer.confirm(message=message, default=default).execute()
+    return utils.prompt_confirm(message, default=default)
+
+
+# ---------------------------------------------------------------------------
+# Interactive flows
+# ---------------------------------------------------------------------------
+
+def _create_site_flow(dry_run: bool) -> None:
+    domain = _text("Main > Create a site > Domain")
+    if not domain:
+        return
+    try:
+        validate_domain(domain)
+    except ValueError as exc:  # pragma: no cover - simple validation path
+        print(exc)
+        return
+    doc_root_default = f"/var/www/{domain}"
+    doc_root = _text("Main > Create a site > Document root", default=doc_root_default)
+    db_name = _text("Main > Create a site > Database name")
+    try:
+        validate_db_identifier(db_name)
+    except ValueError as exc:  # pragma: no cover
+        print(exc)
+        return
+    db_user = _text("Main > Create a site > Database user")
+    try:
+        validate_db_identifier(db_user)
+    except ValueError as exc:  # pragma: no cover
+        print(exc)
+        return
+    db_password = _password("Main > Create a site > Database password")
+    wordpress = _confirm("Main > Create a site > Install WordPress?", default=False)
+    create_site(domain, doc_root, db_name, db_user, db_password, wordpress, dry_run=dry_run)
+
+
+def _uninstall_site_flow(dry_run: bool) -> None:
+    sites = list_installed_sites()
+    if not sites:
+        print("No sites found")
+        return
+    choices = [s["domain"] for s in sites]
+    domain = _select("Main > Uninstall site > Select domain", choices)
+    doc_root = next(s["doc_root"] for s in sites if s["domain"] == domain)
+    db_name = _text("Main > Uninstall site > Database name")
+    db_user = _text("Main > Uninstall site > Database user")
+    if not _confirm(f"Remove site {domain}?", default=False):
+        return
+    if not _confirm("This action is destructive. Continue?", default=False):
+        return
+    remove_db = _confirm("Drop database and user?", default=False)
+    uninstall_site(domain, doc_root, db_name, db_user, remove_db, dry_run=dry_run)
+
+
+def _wp_permissions_flow(dry_run: bool) -> None:
+    doc_root = _text("Main > Set WordPress permissions > Path")
+    if not doc_root:
+        return
+    set_wp_permissions(doc_root, dry_run=dry_run)
+
+
+def _generate_ssl_flow(dry_run: bool) -> None:
+    sites = list_installed_sites()
+    if not sites:
+        print("No domains available")
+        return
+    choices = [s["domain"] for s in sites]
+    domain = _select("Main > Generate SSL certificate > Select domain", choices)
+    generate_ssl(domain, dry_run=dry_run)
+
+
+def _list_sites_flow() -> None:
+    sites = list_installed_sites()
+    for site in sites:
+        print(f"{site['domain']} -> {site['doc_root']}")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def run_menu(dry_run: bool = False) -> None:
+    """Run the interactive menu.
+
+    Args:
+        dry_run: When ``True`` log actions without executing commands.
+    """
+    options = [
+        "Install LAMP server",
+        "Create a site",
+        "Uninstall site",
+        "Set WordPress permissions",
+        "Generate SSL certificate",
+        "List installed sites",
+        "Exit",
+    ]
+    while True:
+        choice = _select("Main > Choose an option", options)
+        if choice == "Install LAMP server":
+            install_lamp(dry_run=dry_run)
+        elif choice == "Create a site":
+            _create_site_flow(dry_run=dry_run)
+        elif choice == "Uninstall site":
+            _uninstall_site_flow(dry_run=dry_run)
+        elif choice == "Set WordPress permissions":
+            _wp_permissions_flow(dry_run=dry_run)
+        elif choice == "Generate SSL certificate":
+            _generate_ssl_flow(dry_run=dry_run)
+        elif choice == "List installed sites":
+            _list_sites_flow()
+        elif choice == "Exit":
+            break

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,53 @@
+import logging
+from typing import List
+
+import logging
+from typing import List
+
+import pytest
+
+from lampkitctl import menu
+
+
+def test_run_menu_routing(monkeypatch):
+    """Ensure menu routes to correct action."""
+    sequence = iter(["Install LAMP server", "Exit"])
+    monkeypatch.setattr(menu, "_select", lambda msg, choices: next(sequence))
+
+    called = {}
+    monkeypatch.setattr(menu, "install_lamp", lambda dry_run: called.setdefault("called", dry_run))
+
+    menu.run_menu(dry_run=True)
+    assert called["called"] is True
+
+
+def test_validate_domain_invalid():
+    """Domain validation should reject malformed names."""
+    with pytest.raises(ValueError):
+        menu.validate_domain("bad_domain")
+
+
+def test_create_site_propagates_and_masks(monkeypatch, caplog):
+    """create_site should pass dry_run and mask sensitive info."""
+    caplog.set_level(logging.INFO)
+    calls: List[tuple] = []
+
+    monkeypatch.setattr(menu.system_ops, "create_web_directory", lambda *a, **k: calls.append(("cwd", k["dry_run"])))
+    monkeypatch.setattr(menu.system_ops, "create_virtualhost", lambda *a, **k: calls.append(("vh", k["dry_run"])))
+    monkeypatch.setattr(menu.system_ops, "enable_site", lambda *a, **k: calls.append(("en", k["dry_run"])))
+    monkeypatch.setattr(menu.system_ops, "add_host_entry", lambda *a, **k: calls.append(("host", k["dry_run"])))
+    monkeypatch.setattr(menu.db_ops, "create_database_and_user", lambda *a, **k: calls.append(("db", k["dry_run"])))
+    monkeypatch.setattr(menu.wp_ops, "install_wordpress", lambda *a, **k: calls.append(("wp", k["dry_run"])))
+
+    menu.create_site(
+        domain="example.com",
+        doc_root="/var/www/example.com",
+        db_name="db",
+        db_user="user",
+        db_password="secret",
+        wordpress=True,
+        dry_run=True,
+    )
+
+    assert all(dry for _, dry in calls)
+    assert "secret" not in caplog.text


### PR DESCRIPTION
## Summary
- add interactive TUI with optional InquirerPy fallback
- wire up `lampkitctl menu` CLI command and document usage
- cover menu controller with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9710cf0083228c9cf8979c10942e