### PR TITLE
feat(preflight): add guards for LAMP prerequisites in CLI and menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It targets both advanced users—through granular commands—and less experience
 
 * [Features](#features)
 * [Requirements](#requirements)
+* [Preflight checks](#preflight-checks)
 * [Security & Warnings](#security--warnings)
 * [Installation](#installation)
 * [Quick Start](#quick-start)
@@ -72,6 +73,32 @@ It targets both advanced users—through granular commands—and less experience
 
 ---
 
+## Preflight checks
+
+Most commands validate that required services and files are present before
+running. If something is missing, **lampkitctl** fails fast with an explicit
+message and suggested fix. Example:
+
+```
+$ lampkitctl --non-interactive create-site example.com --doc-root /var/www/example --db-name db --db-user user --db-password pw
+Preflight failed: create-site
+- Apache not installed. Run: install-lamp.
+- MySQL not installed. Run: install-lamp.
+```
+
+For SSL generation:
+
+```
+$ lampkitctl --non-interactive generate-ssl example.com
+Preflight failed: generate-ssl
+- certbot not installed. Run: apt install certbot python3-certbot-apache.
+```
+
+Use these diagnostics to install missing packages or create required files
+before retrying.
+
+---
+
 ## Security & Warnings
 
 * Some operations are **destructive** (e.g., site/DB removal). The tool asks for confirmation and supports `--dry-run`.
@@ -126,6 +153,9 @@ Legacy: `python main.py --help` also works.
 ---
 
 ## Quick Start
+
+Commands run preflight checks and provide guidance if the environment is
+missing pieces.
 
 ### Install the LAMP stack
 
@@ -186,6 +216,7 @@ sudo lampkitctl uninstall-site example.local \
 
 * `--dry-run` — simulate operations without applying changes.
 * `--verbose` — increase logging verbosity.
+* `--non-interactive` — fail immediately on missing prerequisites.
 
 ### Main commands
 

--- a/lampkitctl/preflight.py
+++ b/lampkitctl/preflight.py
@@ -1,0 +1,177 @@
+"""Preflight checks and utilities for lampkitctl."""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional
+
+import click
+
+from . import utils
+
+# ---------------------------------------------------------------------------
+# Basic check helpers
+# ---------------------------------------------------------------------------
+
+def is_root_or_sudo() -> bool:
+    """Return ``True`` when running as root or via sudo."""
+    return os.geteuid() == 0 or "SUDO_UID" in os.environ
+
+
+def is_supported_os() -> bool:
+    """Check whether the host is a supported Ubuntu release."""
+    try:
+        content = Path("/etc/os-release").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    id_match = re.search(r"^ID=(.*)$", content, re.MULTILINE)
+    ver_match = re.search(r"^VERSION_ID=\"?(.*?)\"?$", content, re.MULTILINE)
+    if not id_match or not ver_match:
+        return False
+    distro = id_match.group(1)
+    version = ver_match.group(1)
+    return distro == "ubuntu" and version in {"20.04", "22.04", "24.04"}
+
+
+def has_cmd(name: str) -> bool:
+    """Return ``True`` if ``name`` is available on ``PATH``."""
+    return shutil.which(name) is not None
+
+
+def service_installed(name: str) -> bool:
+    """Alias for :func:`has_cmd` for semantic clarity."""
+    return has_cmd(name)
+
+
+def service_running(name: str) -> bool:
+    """Return ``True`` if ``systemctl`` reports ``name`` active."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", name],
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def apache_paths_present() -> bool:
+    """Check that Apache configuration directories exist."""
+    return Path("/etc/apache2").exists() and Path("/etc/apache2/sites-available").exists()
+
+
+def can_write(path: str) -> bool:
+    """Return ``True`` if the current user can write to ``path``."""
+    return os.access(path, os.W_OK)
+
+
+def is_wordpress_dir(path: str | Path) -> bool:
+    """Determine whether ``path`` appears to be a WordPress installation."""
+    p = Path(path)
+    return (
+        (p / "wp-config.php").exists()
+        and (p / "wp-content").exists()
+        and (p / "wp-includes").exists()
+    )
+
+# ---------------------------------------------------------------------------
+# Aggregation helpers
+# ---------------------------------------------------------------------------
+
+Check = Callable[[], Optional[str]]
+
+
+def collect_errors(checks: Iterable[Check]) -> List[str]:
+    """Execute ``checks`` and return a list of error messages."""
+    errors: List[str] = []
+    for check in checks:
+        msg = check()
+        if msg:
+            errors.append(msg)
+    return errors
+
+
+def ensure_or_fail(
+    checks: Iterable[Check],
+    command: str,
+    *,
+    exit_code: int = 2,
+    interactive: bool = True,
+) -> None:
+    """Validate ``checks`` and abort if any fail."""
+    errors = collect_errors(checks)
+    if not errors:
+        return
+    click.echo(f"Preflight failed: {command}")
+    for err in errors:
+        click.echo(f"- {err}")
+    if interactive and utils.prompt_confirm("Continue anyway?", default=False):
+        return
+    raise SystemExit(exit_code)
+
+# ---------------------------------------------------------------------------
+# Check factories
+# ---------------------------------------------------------------------------
+
+
+def checks_for(command: str, **kwargs) -> List[Check]:
+    """Return the appropriate preflight checks for ``command``."""
+    domain = kwargs.get("domain", "")
+    doc_root = kwargs.get("doc_root", "")
+
+    if command == "install-lamp":
+        return [
+            lambda: None
+            if is_root_or_sudo()
+            else "Root privileges required. Run with sudo.",
+            lambda: None if has_cmd("apt") else "apt not found. Install apt package manager.",
+            lambda: None if has_cmd("systemctl") else "systemctl not found. Install systemd.",
+            lambda: None
+            if is_supported_os()
+            else "Unsupported OS. Supported: Ubuntu 20.04/22.04/24.04.",
+        ]
+    if command == "create-site":
+        return [
+            lambda: None if has_cmd("apache2") else "Apache not installed. Run: install-lamp.",
+            lambda: None if apache_paths_present() else "Apache paths missing. Run: install-lamp.",
+            lambda: None if has_cmd("mysql") else "MySQL not installed. Run: install-lamp.",
+            lambda: None if has_cmd("php") else "PHP not installed. Run: install-lamp.",
+            lambda: None if can_write("/etc/hosts") else "Cannot write /etc/hosts. Run as root.",
+            lambda: None if can_write("/var/www") else "Cannot write /var/www. Check permissions.",
+        ]
+    if command == "uninstall-site":
+        return [
+            lambda: None if has_cmd("apache2") else "Apache not installed. Run: install-lamp.",
+            lambda: None if apache_paths_present() else "Apache paths missing. Run: install-lamp.",
+            lambda: None if has_cmd("mysql") else "MySQL not installed. Run: install-lamp.",
+            lambda: None if can_write("/etc/hosts") else "Cannot write /etc/hosts. Run as root.",
+            lambda: None if can_write("/var/www") else "Cannot write /var/www. Check permissions.",
+        ]
+    if command == "wp-permissions":
+        return [
+            lambda: None if has_cmd("apache2") else "Apache not installed. Run: install-lamp.",
+            lambda: None if apache_paths_present() else "Apache paths missing. Run: install-lamp.",
+            lambda: None if Path(doc_root).exists() else f"{doc_root} does not exist.",
+            lambda: None
+            if is_wordpress_dir(doc_root)
+            else f"{doc_root} is not a WordPress directory.",
+        ]
+    if command == "generate-ssl":
+        vhost_available = Path(f"/etc/apache2/sites-available/{domain}.conf").exists()
+        vhost_enabled = Path(f"/etc/apache2/sites-enabled/{domain}.conf").exists()
+        return [
+            lambda: None if has_cmd("apache2") else "Apache not installed. Run: install-lamp.",
+            lambda: None if apache_paths_present() else "Apache paths missing. Run: install-lamp.",
+            lambda: None if vhost_available else f"Virtual host {domain} missing. Create the site first.",
+            lambda: None
+            if vhost_enabled
+            else f"Virtual host {domain} not enabled. Run: a2ensite {domain} && systemctl reload apache2.",
+            lambda: None
+            if has_cmd("certbot")
+            else "certbot not installed. Run: apt install certbot python3-certbot-apache.",
+        ]
+    return []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ def test_cli_install_lamp(monkeypatch) -> None:
         monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
     """
     calls = []
+    monkeypatch.setattr(cli.preflight, "ensure_or_fail", lambda *a, **k: None)
     monkeypatch.setattr(cli.system_ops, "check_service", lambda s: False)
     monkeypatch.setattr(
         cli.system_ops, "install_service", lambda s, dry_run: calls.append(s)
@@ -25,6 +26,7 @@ def test_cli_create_site(monkeypatch) -> None:
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
     """
+    monkeypatch.setattr(cli.preflight, "ensure_or_fail", lambda *a, **k: None)
     monkeypatch.setattr(
         cli.system_ops, "create_web_directory", lambda *a, **k: None
     )
@@ -58,6 +60,7 @@ def test_cli_uninstall_site(monkeypatch) -> None:
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
     """
+    monkeypatch.setattr(cli.preflight, "ensure_or_fail", lambda *a, **k: None)
     monkeypatch.setattr(cli.utils, "prompt_confirm", lambda *a, **k: True)
     monkeypatch.setattr(
         cli.system_ops, "remove_virtualhost", lambda *a, **k: None
@@ -86,6 +89,8 @@ def test_cli_list_sites(monkeypatch) -> None:
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
     """
+    monkeypatch.setattr(cli.preflight, "has_cmd", lambda name: True)
+    monkeypatch.setattr(cli.preflight, "apache_paths_present", lambda: True)
     monkeypatch.setattr(
         cli.system_ops, "list_sites", lambda: [{"domain": "a", "doc_root": "/var/www/a"}]
     )

--- a/tests/test_cli_guards.py
+++ b/tests/test_cli_guards.py
@@ -1,0 +1,39 @@
+from click.testing import CliRunner
+
+from lampkitctl import cli, preflight
+
+
+def test_install_lamp_preflight_fail(monkeypatch):
+    monkeypatch.setattr(preflight, "is_root_or_sudo", lambda: False)
+    monkeypatch.setattr(preflight, "has_cmd", lambda name: True)
+    monkeypatch.setattr(preflight, "is_supported_os", lambda: True)
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["--non-interactive", "install-lamp"])
+    assert result.exit_code == 2
+    assert "Preflight failed: install-lamp" in result.output
+
+
+def test_install_lamp_preflight_pass(monkeypatch):
+    monkeypatch.setattr(preflight, "is_root_or_sudo", lambda: True)
+    monkeypatch.setattr(preflight, "has_cmd", lambda name: True)
+    monkeypatch.setattr(preflight, "is_supported_os", lambda: True)
+    monkeypatch.setattr(cli.system_ops, "check_service", lambda s: True)
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["--non-interactive", "install-lamp"])
+    assert result.exit_code == 0
+
+
+def test_generate_ssl_missing_certbot(monkeypatch):
+    def fake_has_cmd(name):
+        return False if name == "certbot" else True
+
+    monkeypatch.setattr(preflight, "has_cmd", fake_has_cmd)
+    monkeypatch.setattr(preflight, "apache_paths_present", lambda: True)
+    monkeypatch.setattr(preflight.Path, "exists", lambda self: True)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["--non-interactive", "generate-ssl", "example.com"],
+    )
+    assert result.exit_code == 2
+    assert "certbot not installed" in result.output

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -15,6 +15,7 @@ def test_run_menu_routing(monkeypatch):
     monkeypatch.setattr(menu, "_select", lambda msg, choices: next(sequence))
 
     called = {}
+    monkeypatch.setattr(menu.preflight, "ensure_or_fail", lambda *a, **k: None)
     monkeypatch.setattr(menu, "install_lamp", lambda dry_run: called.setdefault("called", dry_run))
 
     menu.run_menu(dry_run=True)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from lampkitctl import preflight
+
+
+def test_is_root_or_sudo(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    assert preflight.is_root_or_sudo()
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("SUDO_UID", raising=False)
+    assert not preflight.is_root_or_sudo()
+
+
+def test_is_supported_os(monkeypatch):
+    data = "ID=ubuntu\nVERSION_ID=\"22.04\"\n"
+    monkeypatch.setattr(Path, "read_text", lambda self, encoding=None: data)
+    assert preflight.is_supported_os()
+    data = "ID=ubuntu\nVERSION_ID=\"18.04\"\n"
+    monkeypatch.setattr(Path, "read_text", lambda self, encoding=None: data)
+    assert not preflight.is_supported_os()
+
+
+def test_has_cmd(monkeypatch):
+    monkeypatch.setattr(preflight.shutil, "which", lambda n: "/bin/true")
+    assert preflight.has_cmd("true")
+    monkeypatch.setattr(preflight.shutil, "which", lambda n: None)
+    assert not preflight.has_cmd("true")
+
+
+def test_service_running(monkeypatch):
+    class R:
+        returncode = 0
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: R())
+    assert preflight.service_running("apache2")
+
+    class F:
+        returncode = 3
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: F())
+    assert not preflight.service_running("apache2")
+
+
+def test_apache_paths_present(monkeypatch):
+    def fake_exists(self):
+        return str(self) in {"/etc/apache2", "/etc/apache2/sites-available"}
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    assert preflight.apache_paths_present()
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    assert not preflight.apache_paths_present()
+
+
+def test_can_write(monkeypatch):
+    monkeypatch.setattr(os, "access", lambda p, m: True)
+    assert preflight.can_write("/tmp")
+    monkeypatch.setattr(os, "access", lambda p, m: False)
+    assert not preflight.can_write("/tmp")
+
+
+def test_is_wordpress_dir(tmp_path):
+    (tmp_path / "wp-config.php").write_text("")
+    (tmp_path / "wp-content").mkdir()
+    (tmp_path / "wp-includes").mkdir()
+    assert preflight.is_wordpress_dir(tmp_path)
+    assert not preflight.is_wordpress_dir(tmp_path / "empty")
+
+
+def test_collect_errors_and_ensure(monkeypatch):
+    checks = [lambda: "missing", lambda: None]
+    assert preflight.collect_errors(checks) == ["missing"]
+    with pytest.raises(SystemExit):
+        preflight.ensure_or_fail(checks, "cmd", interactive=False)
+    # interactive continue
+    monkeypatch.setattr(preflight.utils, "prompt_confirm", lambda *a, **k: True)
+    preflight.ensure_or_fail(checks, "cmd", interactive=True)


### PR DESCRIPTION
## Summary
- add centralized preflight module with environment and service checks
- guard CLI commands and menu actions with preflight validation
- document new preflight behaviour and non-interactive flag

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb8e366588322a5010c4e4fa75a3d