### PR TITLE
fix(install-lamp): block on missing root; add apt error handling; unify CLI+menu guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,12 @@ Preflight failed: generate-ssl
 - certbot not installed. Run: apt install certbot python3-certbot-apache.
 ```
 
-Use these diagnostics to install missing packages or create required files
-before retrying.
+Critical prerequisites are **blocking** and abort the command with exit code `2`
+without an override prompt (e.g., running `install-lamp` without `sudo`). Use
+`--dry-run` to preview actions even when blocking checks fail.
+
+Use these diagnostics to install missing packages or create required files before
+retrying.
 
 ---
 

--- a/lampkitctl/system_ops.py
+++ b/lampkitctl/system_ops.py
@@ -48,8 +48,8 @@ def install_service(service: str, dry_run: bool = False) -> None:
         >>> install_service("apache2", dry_run=True)
     """
     cmd = ["apt-get", "install", "-y", service]
-    run_command(["apt-get", "update"], dry_run)
-    run_command(cmd, dry_run)
+    run_command(["apt-get", "update"], dry_run, capture_output=True)
+    run_command(cmd, dry_run, capture_output=True)
 
 
 def create_web_directory(path: str, dry_run: bool = False) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,8 +89,14 @@ def test_cli_list_sites(monkeypatch) -> None:
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
     """
-    monkeypatch.setattr(cli.preflight, "has_cmd", lambda name: True)
-    monkeypatch.setattr(cli.preflight, "apache_paths_present", lambda: True)
+    monkeypatch.setattr(
+        cli.preflight,
+        "has_cmd",
+        lambda name, msg=None, severity=cli.preflight.Severity.BLOCKING: cli.preflight.CheckResult(True, ""),
+    )
+    monkeypatch.setattr(
+        cli.preflight, "apache_paths_present", lambda: cli.preflight.CheckResult(True, "")
+    )
     monkeypatch.setattr(
         cli.system_ops, "list_sites", lambda: [{"domain": "a", "doc_root": "/var/www/a"}]
     )

--- a/tests/test_cli_guards.py
+++ b/tests/test_cli_guards.py
@@ -4,19 +4,39 @@ from lampkitctl import cli, preflight
 
 
 def test_install_lamp_preflight_fail(monkeypatch):
-    monkeypatch.setattr(preflight, "is_root_or_sudo", lambda: False)
-    monkeypatch.setattr(preflight, "has_cmd", lambda name: True)
-    monkeypatch.setattr(preflight, "is_supported_os", lambda: True)
+    monkeypatch.setattr(
+        preflight,
+        "is_root_or_sudo",
+        lambda: preflight.CheckResult(False, "root"),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "has_cmd",
+        lambda name, msg=None, severity=preflight.Severity.BLOCKING: preflight.CheckResult(True, name),
+    )
+    monkeypatch.setattr(
+        preflight, "is_supported_os", lambda: preflight.CheckResult(True, "")
+    )
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["--non-interactive", "install-lamp"])
     assert result.exit_code == 2
-    assert "Preflight failed: install-lamp" in result.output
+    assert "Preflight failed" in result.output
 
 
 def test_install_lamp_preflight_pass(monkeypatch):
-    monkeypatch.setattr(preflight, "is_root_or_sudo", lambda: True)
-    monkeypatch.setattr(preflight, "has_cmd", lambda name: True)
-    monkeypatch.setattr(preflight, "is_supported_os", lambda: True)
+    monkeypatch.setattr(
+        preflight,
+        "is_root_or_sudo",
+        lambda: preflight.CheckResult(True, "root"),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "has_cmd",
+        lambda name, msg=None, severity=preflight.Severity.BLOCKING: preflight.CheckResult(True, name),
+    )
+    monkeypatch.setattr(
+        preflight, "is_supported_os", lambda: preflight.CheckResult(True, "")
+    )
     monkeypatch.setattr(cli.system_ops, "check_service", lambda s: True)
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["--non-interactive", "install-lamp"])
@@ -24,11 +44,14 @@ def test_install_lamp_preflight_pass(monkeypatch):
 
 
 def test_generate_ssl_missing_certbot(monkeypatch):
-    def fake_has_cmd(name):
-        return False if name == "certbot" else True
+    def fake_has_cmd(name, msg=None, severity=preflight.Severity.BLOCKING):
+        ok = False if name == "certbot" else True
+        return preflight.CheckResult(ok, msg or name)
 
     monkeypatch.setattr(preflight, "has_cmd", fake_has_cmd)
-    monkeypatch.setattr(preflight, "apache_paths_present", lambda: True)
+    monkeypatch.setattr(
+        preflight, "apache_paths_present", lambda: preflight.CheckResult(True, "")
+    )
     monkeypatch.setattr(preflight.Path, "exists", lambda self: True)
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_menu_guards.py
+++ b/tests/test_menu_guards.py
@@ -1,0 +1,28 @@
+from lampkitctl import menu, preflight
+
+
+def test_menu_install_lamp_blocking(monkeypatch, capsys):
+    sequence = iter(["Install LAMP server", "Exit"])
+    monkeypatch.setattr(menu, "_select", lambda msg, choices: next(sequence))
+    monkeypatch.setattr(
+        preflight,
+        "is_root_or_sudo",
+        lambda: preflight.CheckResult(False, "Root privileges required. Run with sudo."),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "has_cmd",
+        lambda name, msg=None, severity=preflight.Severity.BLOCKING: preflight.CheckResult(True, ""),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "is_supported_os",
+        lambda: preflight.CheckResult(True, ""),
+    )
+    calls = []
+    monkeypatch.setattr(menu.system_ops, "install_service", lambda *a, **k: calls.append(a))
+    menu.run_menu()
+    captured = capsys.readouterr()
+    assert "Preflight failed" in captured.err
+    assert calls == []
+    assert "Traceback" not in captured.err

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -9,26 +9,26 @@ from lampkitctl import preflight
 
 def test_is_root_or_sudo(monkeypatch):
     monkeypatch.setattr(os, "geteuid", lambda: 0)
-    assert preflight.is_root_or_sudo()
+    assert preflight.is_root_or_sudo().ok
     monkeypatch.setattr(os, "geteuid", lambda: 1000)
     monkeypatch.delenv("SUDO_UID", raising=False)
-    assert not preflight.is_root_or_sudo()
+    assert not preflight.is_root_or_sudo().ok
 
 
 def test_is_supported_os(monkeypatch):
     data = "ID=ubuntu\nVERSION_ID=\"22.04\"\n"
     monkeypatch.setattr(Path, "read_text", lambda self, encoding=None: data)
-    assert preflight.is_supported_os()
+    assert preflight.is_supported_os().ok
     data = "ID=ubuntu\nVERSION_ID=\"18.04\"\n"
     monkeypatch.setattr(Path, "read_text", lambda self, encoding=None: data)
-    assert not preflight.is_supported_os()
+    assert not preflight.is_supported_os().ok
 
 
 def test_has_cmd(monkeypatch):
     monkeypatch.setattr(preflight.shutil, "which", lambda n: "/bin/true")
-    assert preflight.has_cmd("true")
+    assert preflight.has_cmd("true").ok
     monkeypatch.setattr(preflight.shutil, "which", lambda n: None)
-    assert not preflight.has_cmd("true")
+    assert not preflight.has_cmd("true").ok
 
 
 def test_service_running(monkeypatch):
@@ -50,31 +50,35 @@ def test_apache_paths_present(monkeypatch):
         return str(self) in {"/etc/apache2", "/etc/apache2/sites-available"}
 
     monkeypatch.setattr(Path, "exists", fake_exists)
-    assert preflight.apache_paths_present()
+    assert preflight.apache_paths_present().ok
     monkeypatch.setattr(Path, "exists", lambda self: False)
-    assert not preflight.apache_paths_present()
+    assert not preflight.apache_paths_present().ok
 
 
 def test_can_write(monkeypatch):
     monkeypatch.setattr(os, "access", lambda p, m: True)
-    assert preflight.can_write("/tmp")
+    assert preflight.can_write("/tmp").ok
     monkeypatch.setattr(os, "access", lambda p, m: False)
-    assert not preflight.can_write("/tmp")
+    assert not preflight.can_write("/tmp").ok
 
 
 def test_is_wordpress_dir(tmp_path):
     (tmp_path / "wp-config.php").write_text("")
     (tmp_path / "wp-content").mkdir()
     (tmp_path / "wp-includes").mkdir()
-    assert preflight.is_wordpress_dir(tmp_path)
-    assert not preflight.is_wordpress_dir(tmp_path / "empty")
+    assert preflight.is_wordpress_dir(tmp_path).ok
+    assert not preflight.is_wordpress_dir(tmp_path / "empty").ok
 
 
-def test_collect_errors_and_ensure(monkeypatch):
-    checks = [lambda: "missing", lambda: None]
-    assert preflight.collect_errors(checks) == ["missing"]
+def test_ensure_or_fail(monkeypatch):
+    checks = [preflight.CheckResult(False, "missing")]
     with pytest.raises(SystemExit):
-        preflight.ensure_or_fail(checks, "cmd", interactive=False)
-    # interactive continue
-    monkeypatch.setattr(preflight.utils, "prompt_confirm", lambda *a, **k: True)
-    preflight.ensure_or_fail(checks, "cmd", interactive=True)
+        preflight.ensure_or_fail(checks, interactive=False)
+    # interactive warning path
+    monkeypatch.setattr(
+        preflight.utils, "prompt_confirm", lambda *a, **k: True
+    )
+    checks = [
+        preflight.CheckResult(False, "warn", preflight.Severity.WARNING)
+    ]
+    preflight.ensure_or_fail(checks, interactive=True)

--- a/tests/test_preflight_root.py
+++ b/tests/test_preflight_root.py
@@ -1,0 +1,26 @@
+from click.testing import CliRunner
+
+from lampkitctl import cli, preflight
+
+
+def test_install_lamp_requires_root(monkeypatch):
+    monkeypatch.setattr(
+        preflight,
+        "is_root_or_sudo",
+        lambda: preflight.CheckResult(False, "Root privileges required. Run with sudo."),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "has_cmd",
+        lambda name, msg=None, severity=preflight.Severity.BLOCKING: preflight.CheckResult(True, ""),
+    )
+    monkeypatch.setattr(
+        preflight, "is_supported_os", lambda: preflight.CheckResult(True, "")
+    )
+    calls = []
+    monkeypatch.setattr(cli.system_ops, "install_service", lambda *a, **k: calls.append(a))
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["install-lamp"])
+    assert result.exit_code == 2
+    assert "Root privileges required" in result.output
+    assert calls == []

--- a/tests/test_system_ops.py
+++ b/tests/test_system_ops.py
@@ -46,7 +46,9 @@ def test_install_service(monkeypatch) -> None:
         monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
     """
     calls = []
-    monkeypatch.setattr(system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
+    monkeypatch.setattr(
+        system_ops, "run_command", lambda cmd, dry_run, **k: calls.append(cmd)
+    )
     system_ops.install_service("apache2", dry_run=True)
     assert calls[1] == ["apt-get", "install", "-y", "apache2"]
 
@@ -71,7 +73,9 @@ def test_enable_site(monkeypatch) -> None:
         monkeypatch (pytest.MonkeyPatch): Fixture for patching objects.
     """
     calls = []
-    monkeypatch.setattr(system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
+    monkeypatch.setattr(
+        system_ops, "run_command", lambda cmd, dry_run, **k: calls.append(cmd)
+    )
     system_ops.enable_site("example.com", dry_run=True)
     assert calls[0][0] == "a2ensite"
 
@@ -84,6 +88,8 @@ def test_create_web_directory(monkeypatch, tmp_path) -> None:
         tmp_path (pathlib.Path): Temporary directory provided by pytest.
     """
     calls = []
-    monkeypatch.setattr(system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
+    monkeypatch.setattr(
+        system_ops, "run_command", lambda cmd, dry_run, **k: calls.append(cmd)
+    )
     system_ops.create_web_directory(str(tmp_path / "web"), dry_run=True)
     assert calls[0][0] == "mkdir"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ def test_run_command_dry_run(monkeypatch) -> None:
     """
     called = False
 
-    def fake_run(cmd, check, text):
+    def fake_run(cmd, **kwargs):
         nonlocal called
         called = True
         return subprocess.CompletedProcess(cmd, 0, "", "")
@@ -29,7 +29,7 @@ def test_run_command_executes(monkeypatch) -> None:
     """
     recorded = {}
 
-    def fake_run(cmd, check, text):
+    def fake_run(cmd, **kwargs):
         recorded["cmd"] = cmd
         return subprocess.CompletedProcess(cmd, 0, "out", "err")
 

--- a/tests/test_utils_apt_errors.py
+++ b/tests/test_utils_apt_errors.py
@@ -1,0 +1,25 @@
+import subprocess
+
+from lampkitctl import utils
+
+
+def test_classify_permission_denied():
+    err = subprocess.CalledProcessError(
+        100,
+        ["apt-get", "install"],
+        output="Permission denied",
+        stderr="Permission denied",
+    )
+    msg = utils.classify_apt_error(err)
+    assert "APT failed" in msg
+
+
+def test_classify_lock_issue():
+    err = subprocess.CalledProcessError(
+        1,
+        ["apt-get", "install"],
+        output="Could not get lock",
+        stderr="",
+    )
+    msg = utils.classify_apt_error(err)
+    assert "lock" in msg.lower()


### PR DESCRIPTION
## Summary
- add severity-aware preflight checks with blocking failures
- stop install-lamp when not run as root and reuse checks in menu
- catch apt failures with friendly diagnostics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cbc2319b083228e70b7c5deb63528