### PR TITLE
feat(elevate): sudo/venv compatibility via auto re-exec; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,19 @@ pip install -e .
 lampkitctl --help
 # or
 python -m lampkitctl --help
+
+# Run CLI under sudo while keeping the venv path
+sudo "$(command -v lampkitctl)" menu
+sudo "$(command -v lampkitctl)" install-lamp
+
+# Alternative module runner
+sudo "$(command -v python)" -m lampkitctl install-lamp
 ```
+
+Some systems configure ``sudo`` with ``secure_path`` which resets ``PATH`` and
+causes ``sudo lampkitctl`` to fail with ``command not found`` when the CLI lives
+inside a virtualenv. Using ``$(command -v lampkitctl)`` provides the absolute
+path to the current executable and works reliably.
 
 Legacy: `python main.py --help` also works.
 
@@ -161,18 +173,24 @@ Legacy: `python main.py --help` also works.
 Commands run preflight checks and provide guidance if the environment is
 missing pieces.
 
+### Launch the interactive menu
+
+```bash
+sudo "$(command -v lampkitctl)" menu
+```
+
 ### Install the LAMP stack
 
 ```bash
-sudo lampkitctl install-lamp
+sudo "$(command -v lampkitctl)" install-lamp
 # or simulate without changes:
-sudo lampkitctl install-lamp --dry-run
+sudo "$(command -v lampkitctl)" install-lamp --dry-run
 ```
 
 ### Create a site
 
 ```bash
-sudo lampkitctl create-site example.local \
+sudo "$(command -v lampkitctl)" create-site example.local \
   --doc-root /var/www/example.local \
   --db-name example_db \
   --db-user example_user \
@@ -186,25 +204,25 @@ sudo lampkitctl create-site example.local \
 ### Issue an SSL certificate (Certbot)
 
 ```bash
-sudo lampkitctl generate-ssl example.local
+sudo "$(command -v lampkitctl)" generate-ssl example.local
 ```
 
 ### Set WordPress permissions
 
 ```bash
-sudo lampkitctl wp-permissions /var/www/example.local
+sudo "$(command -v lampkitctl)" wp-permissions /var/www/example.local
 ```
 
 ### List configured sites
 
 ```bash
-sudo lampkitctl list-sites
+sudo "$(command -v lampkitctl)" list-sites
 ```
 
 ### Remove a site
 
 ```bash
-sudo lampkitctl uninstall-site example.local \
+sudo "$(command -v lampkitctl)" uninstall-site example.local \
   --doc-root /var/www/example.local \
   --db-name example_db \
   --db-user example_user
@@ -215,6 +233,7 @@ sudo lampkitctl uninstall-site example.local \
 ## CLI Reference
 
 > Exact command names/options may vary slightly by version. Run `lampkitctl --help` for the current details.
+> From a virtualenv, prefix privileged commands with `sudo "$(command -v lampkitctl)"`.
 
 ### Global options
 

--- a/lampkitctl/elevate.py
+++ b/lampkitctl/elevate.py
@@ -1,0 +1,80 @@
+"""Helpers to elevate commands using ``sudo`` while preserving the venv."""
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import sys
+
+
+def resolve_self_executable() -> str:
+    """Return the absolute path to the current ``lampkitctl`` executable.
+
+    The lookup prefers the console script referenced by ``sys.argv[0]`` and
+    falls back to searching ``PATH``. If neither is available, an empty string
+    is returned so the caller can choose a ``python -m`` invocation instead.
+    """
+
+    argv0 = os.path.realpath(sys.argv[0])
+    if os.path.isfile(argv0) and os.access(argv0, os.X_OK):
+        return argv0
+
+    found = shutil.which("lampkitctl")
+    if found:
+        return os.path.realpath(found)
+
+    return ""
+
+
+def build_sudo_cmd(argv: list[str]) -> list[str]:
+    """Return a command that re-executes ``lampkitctl`` under ``sudo``.
+
+    Args:
+        argv: Original argument vector.
+
+    Returns:
+        List of command parts suitable for :func:`os.execvp`.
+    """
+
+    exe = resolve_self_executable()
+    if exe:
+        return ["sudo", exe] + argv[1:]
+    return ["sudo", sys.executable, "-m", "lampkitctl"] + argv[1:]
+
+
+def maybe_reexec_with_sudo(
+    argv: list[str], *, non_interactive: bool, dry_run: bool
+) -> None:
+    """Re-execute the current command under ``sudo`` if not already root.
+
+    In non-interactive mode the function prints guidance and exits with code 2
+    instead of prompting. ``dry_run`` bypasses any elevation logic.
+    """
+
+    if dry_run:
+        return
+
+    try:
+        is_root = os.geteuid() == 0
+    except AttributeError:  # pragma: no cover - non-POSIX
+        is_root = False
+    if is_root:
+        return
+
+    from .utils import echo_err, is_non_interactive, prompt_yes_no
+
+    if non_interactive or is_non_interactive():
+        echo_err(
+            "Root privileges required. Re-run with: "
+            "sudo $(command -v lampkitctl) …  or sudo /full/path/to/.venv/bin/lampkitctl …"
+        )
+        raise SystemExit(2)
+
+    proceed = prompt_yes_no("Root required. Re-run with sudo now?", default=True)
+    if not proceed:
+        raise SystemExit(2)
+
+    cmd = build_sudo_cmd(argv)
+    print("Re-running as root:", " ".join(shlex.quote(a) for a in cmd))
+    os.execvp(cmd[0], cmd)
+

--- a/lampkitctl/menu.py
+++ b/lampkitctl/menu.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 import getpass
 import logging
 import re
+import sys
 from typing import Iterable, List, Optional
 
-from . import db_ops, system_ops, utils, wp_ops, preflight
+from . import db_ops, preflight, system_ops, utils, wp_ops
+from .elevate import maybe_reexec_with_sudo
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +69,7 @@ def install_lamp(dry_run: bool = False) -> None:
     Args:
         dry_run: When ``True`` log actions without executing.
     """
+    maybe_reexec_with_sudo(sys.argv, non_interactive=False, dry_run=dry_run)
     checks = preflight.checks_for("install-lamp")
     try:
         preflight.ensure_or_fail(checks, dry_run=dry_run)
@@ -102,6 +105,7 @@ def create_site(
         wordpress: If ``True`` install WordPress.
         dry_run: Log actions without executing.
     """
+    maybe_reexec_with_sudo(sys.argv, non_interactive=False, dry_run=dry_run)
     logger.info(
         "create_site",
         extra={
@@ -140,6 +144,7 @@ def uninstall_site(
         remove_db: If ``True`` drop database and user.
         dry_run: Log actions without executing.
     """
+    maybe_reexec_with_sudo(sys.argv, non_interactive=False, dry_run=dry_run)
     logger.info("uninstall_site", extra={"domain": domain, "dry_run": dry_run})
     system_ops.remove_virtualhost(domain, dry_run=dry_run)
     system_ops.remove_host_entry(domain, dry_run=dry_run)
@@ -155,6 +160,7 @@ def set_wp_permissions(doc_root: str, dry_run: bool = False) -> None:
         doc_root: Path to the WordPress installation.
         dry_run: Log actions without executing.
     """
+    maybe_reexec_with_sudo(sys.argv, non_interactive=False, dry_run=dry_run)
     logger.info("set_wp_permissions", extra={"doc_root": doc_root, "dry_run": dry_run})
     wp_ops.set_permissions(doc_root, dry_run=dry_run)
 
@@ -166,6 +172,7 @@ def generate_ssl(domain: str, dry_run: bool = False) -> None:
         domain: Domain for the certificate.
         dry_run: Log actions without executing.
     """
+    maybe_reexec_with_sudo(sys.argv, non_interactive=False, dry_run=dry_run)
     logger.info("generate_ssl", extra={"domain": domain, "dry_run": dry_run})
     utils.run_command(["certbot", "--apache", "-d", domain], dry_run)
 

--- a/lampkitctl/utils.py
+++ b/lampkitctl/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+import sys
 from typing import Iterable, List, Optional
 
 
@@ -177,3 +178,31 @@ def prompt_confirm(message: str, default: bool = False) -> bool:
         if resp in {"n", "no"}:
             return False
         print("Please respond with 'y' or 'n'.")
+
+
+def prompt_yes_no(message: str, default: bool = False) -> bool:
+    """Prompt the user for a yes/no response.
+
+    This is a thin wrapper around :func:`prompt_confirm` for semantic clarity.
+
+    Args:
+        message: Prompt to display.
+        default: Default value when the user presses enter.
+
+    Returns:
+        ``True`` if the user confirms, ``False`` otherwise.
+    """
+
+    return prompt_confirm(message, default=default)
+
+
+def echo_err(message: str) -> None:
+    """Print ``message`` to standard error."""
+
+    print(message, file=sys.stderr)
+
+
+def is_non_interactive() -> bool:
+    """Return ``True`` if stdin is not attached to a TTY."""
+
+    return not sys.stdin.isatty()

--- a/tests/test_elevate.py
+++ b/tests/test_elevate.py
@@ -1,0 +1,60 @@
+"""Tests for elevation helpers."""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from lampkitctl import elevate, utils
+
+
+def test_build_sudo_cmd_uses_executable(monkeypatch) -> None:
+    """build_sudo_cmd should prefer the console script path."""
+
+    monkeypatch.setattr(elevate, "resolve_self_executable", lambda: "/venv/bin/lampkitctl")
+    cmd = elevate.build_sudo_cmd(["/venv/bin/lampkitctl", "install-lamp", "--x"])
+    assert cmd == ["sudo", "/venv/bin/lampkitctl", "install-lamp", "--x"]
+
+
+def test_build_sudo_cmd_fallback(monkeypatch) -> None:
+    """Fallback to module runner when executable is not found."""
+
+    monkeypatch.setattr(elevate, "resolve_self_executable", lambda: "")
+    cmd = elevate.build_sudo_cmd(["lampkitctl", "install-lamp"])
+    assert cmd[:4] == ["sudo", sys.executable, "-m", "lampkitctl"]
+
+
+def test_maybe_reexec_execs(monkeypatch) -> None:
+    """When not root and interactive, the process should exec sudo."""
+
+    monkeypatch.setattr(elevate.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(elevate, "build_sudo_cmd", lambda argv: ["sudo", "/venv/bin/lampkitctl"] + argv[1:])
+    monkeypatch.setattr(utils, "prompt_yes_no", lambda *a, **k: True)
+    monkeypatch.setattr(utils, "is_non_interactive", lambda: False)
+    called = {}
+    monkeypatch.setattr(elevate.os, "execvp", lambda *a: called.setdefault("cmd", list(a)))
+    elevate.maybe_reexec_with_sudo(["lampkitctl", "install-lamp"], non_interactive=False, dry_run=False)
+    assert called["cmd"] == ["sudo", ["sudo", "/venv/bin/lampkitctl", "install-lamp"]]
+
+
+def test_maybe_reexec_non_interactive(monkeypatch, capsys) -> None:
+    """Non-interactive runs should exit with guidance."""
+
+    monkeypatch.setattr(elevate.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(utils, "is_non_interactive", lambda: False)
+    monkeypatch.setattr(utils, "echo_err", lambda msg: print(msg, file=sys.stderr))
+    with pytest.raises(SystemExit) as exc:
+        elevate.maybe_reexec_with_sudo(["lampkitctl"], non_interactive=True, dry_run=False)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "sudo $(command -v lampkitctl)" in err
+
+
+def test_maybe_reexec_dry_run(monkeypatch) -> None:
+    """Dry-run should bypass elevation logic."""
+
+    monkeypatch.setattr(elevate.os, "geteuid", lambda: 1000)
+    called = {}
+    monkeypatch.setattr(elevate.os, "execvp", lambda *a: called.setdefault("cmd", list(a)))
+    elevate.maybe_reexec_with_sudo(["lampkitctl"], non_interactive=False, dry_run=True)
+    assert called == {}


### PR DESCRIPTION
## Summary
- add `elevate` helper that resolves current script and re-runs under sudo using absolute paths
- call sudo re-exec from CLI and menu for commands needing root
- document how to run the tool from a venv with sudo, plus add tests

## Testing
- `pytest -q`
- Manual: `python - <<'PY'
from lampkitctl.elevate import maybe_reexec_with_sudo
from lampkitctl import utils, elevate
import os
os.geteuid = lambda: 1000
utils.prompt_yes_no = lambda *a, **k: True
utils.is_non_interactive = lambda: False
elevate.build_sudo_cmd = lambda argv: ["sudo", "/venv/bin/lampkitctl"] + argv[1:]

def fake_execvp(file, args):
    print("execvp called:", file, args)
os.execvp = fake_execvp
maybe_reexec_with_sudo(["lampkitctl", "install-lamp"], non_interactive=False, dry_run=False)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689cc11653f883229cb0dc59c9ddf327