### PR TITLE
fix(menu): resume selected action after sudo (no menu loop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ lampkitctl install-launcher  # run once to enable sudo lampkitctl
 sudo lampkitctl menu
 ```
 
+When elevation is required, the tool continues the chosen action after
+acquiring sudo; you do not need to re-select options.
+
 ### Install the LAMP stack
 
 ```bash

--- a/tests/test_menu_resume.py
+++ b/tests/test_menu_resume.py
@@ -1,0 +1,51 @@
+import pytest
+
+from lampkitctl import menu
+
+def test_menu_install_lamp_execs_sudo(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(menu, "resolve_self_executable", lambda: "/abs/path/to/lampkitctl")
+    monkeypatch.setattr(menu.os, "geteuid", lambda: 1000)
+
+    def fake_execvp(file, args):
+        captured["cmd"] = args
+        raise SystemExit()
+
+    monkeypatch.setattr(menu.os, "execvp", fake_execvp)
+
+    responses = iter(["Install LAMP server", "MySQL"])
+    monkeypatch.setattr(menu, "_select", lambda message, choices: next(responses))
+
+    with pytest.raises(SystemExit):
+        menu.run_menu(dry_run=False)
+
+    assert captured["cmd"] == [
+        "sudo",
+        "/abs/path/to/lampkitctl",
+        "install-lamp",
+        "--db-engine",
+        "mysql",
+    ]
+
+
+def test_run_cli_root_calls_subprocess(monkeypatch):
+    monkeypatch.setattr(menu, "resolve_self_executable", lambda: "/abs/path/to/lampkitctl")
+    monkeypatch.setattr(menu.os, "geteuid", lambda: 0)
+    called = {}
+
+    def fake_call(args):
+        called["args"] = args
+        return 0
+
+    monkeypatch.setattr(menu.subprocess, "call", fake_call)
+
+    rc = menu._run_cli(["install-lamp", "--db-engine", "mysql"], dry_run=False)
+
+    assert rc == 0
+    assert called["args"] == [
+        "/abs/path/to/lampkitctl",
+        "install-lamp",
+        "--db-engine",
+        "mysql",
+    ]


### PR DESCRIPTION
## Summary
- route menu actions through CLI and re-exec with sudo so selected tasks resume after elevation
- simplify sudo command construction and ensure re-exec builds full argv
- document new menu behaviour and add regression tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cca3ef6f88322ab330144eacf0f5c