### PR TITLE
fix(install): block apt lock and fix DB detection false-negative; menu resume; docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,19 +200,21 @@ sudo lampkitctl install-lamp --db-engine mariadb
 sudo lampkitctl install-lamp --db-engine auto --dry-run
 ```
 
+> **Note:** The install will abort if another apt/dpkg process holds the lock.
+> Wait for it to finish or close other package managers.
+
 ### Database engine detection
 
-`install-lamp` tries to install `mysql-server` when available and falls back to
-`mariadb-server`. Override the choice with `--db-engine mysql` or
-`--db-engine mariadb`.
+`install-lamp` refreshes the apt cache and picks `mysql-server` when available,
+falling back to `mariadb-server`. Override the choice with `--db-engine mysql`
+or `--db-engine mariadb`.
 
 ### Troubleshooting
 
-- **Package not found** – run `sudo apt-get update` and verify the package name
-  matches your Ubuntu release. If you meant MySQL, use `mysql-server`; for
-  MariaDB, use `mariadb-server`.
-- **APT lock** – another package manager is running. Close Software
-  Updater/apt/dpkg or wait for unattended upgrades.
+- **Package not found** – run `sudo apt-get update`, ensure your Ubuntu release
+  is supported, or try `--db-engine mariadb` if MySQL packages are missing.
+- **APT lock** – another package manager is running. Wait or close apt/dpkg
+  processes. Inspect with `ps aux | egrep 'apt|dpkg'`.
 
 ### Create a site
 

--- a/lampkitctl/menu.py
+++ b/lampkitctl/menu.py
@@ -383,6 +383,7 @@ def run_menu(dry_run: bool = False) -> None:
                 ],
                 dry_run=dry_run,
             )
+            return
         elif choice == "Create a site":
             try:
                 preflight.ensure_or_fail(

--- a/lampkitctl/packages.py
+++ b/lampkitctl/packages.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
+
+import re
 import subprocess
 from dataclasses import dataclass
+
+from . import utils
 
 
 @dataclass
@@ -11,8 +15,14 @@ class Engine:
     service_name: str
 
 
+CANDIDATE_RX = re.compile(
+    r"^\s*Candidate:\s*(?!\(none\))", re.IGNORECASE | re.MULTILINE
+)
+
+
 def apt_has_package(pkg: str) -> bool:
     """Return ``True`` if ``apt`` reports a candidate for ``pkg``."""
+
     try:
         p = subprocess.run(
             ["apt-cache", "policy", pkg], capture_output=True, text=True
@@ -22,24 +32,51 @@ def apt_has_package(pkg: str) -> bool:
     if p.returncode != 0:
         return False
     out = (p.stdout or "") + (p.stderr or "")
-    return "Candidate:" in out and "(none)" not in out
+    return bool(CANDIDATE_RX.search(out))
+
+
+def _candidate_line(pkg: str) -> str:
+    try:
+        p = subprocess.run(
+            ["apt-cache", "policy", pkg], capture_output=True, text=True
+        )
+    except OSError:
+        return "Candidate: (error)"
+    out = (p.stdout or "") + (p.stderr or "")
+    m = re.search(r"^\s*Candidate:.*$", out, re.MULTILINE)
+    return m.group(0).strip() if m else "Candidate: (none)"
+
+
+def refresh_cache(dry_run: bool = False) -> None:
+    utils.run_command(["apt-get", "update"], dry_run=dry_run, capture_output=True)
 
 
 def detect_db_engine(preferred: str | None = None) -> Engine:
     """Detect a suitable database engine package."""
-    if preferred in {"mysql", "mariadb"}:
-        if preferred == "mysql" and apt_has_package("mysql-server"):
-            return Engine("mysql", "mysql-server", "mysql-client", "mysql")
-        if preferred == "mariadb" and apt_has_package("mariadb-server"):
-            return Engine("mariadb", "mariadb-server", "mariadb-client", "mariadb")
-        # Fall through to auto
+
+    if preferred == "auto":
+        preferred = None
+    if preferred == "mysql" and apt_has_package("mysql-server"):
+        return Engine("mysql", "mysql-server", "mysql-client", "mysql")
+    if preferred == "mariadb" and apt_has_package("mariadb-server"):
+        return Engine("mariadb", "mariadb-server", "mariadb-client", "mariadb")
+
     if apt_has_package("mysql-server"):
         return Engine("mysql", "mysql-server", "mysql-client", "mysql")
     if apt_has_package("mariadb-server"):
         return Engine("mariadb", "mariadb-server", "mariadb-client", "mariadb")
+    if apt_has_package("default-mysql-server"):
+        return Engine(
+            "mysql", "default-mysql-server", "default-mysql-client", "mysql"
+        )
+
+    lines = [
+        f"mysql-server: {_candidate_line('mysql-server')}",
+        f"mariadb-server: {_candidate_line('mariadb-server')}",
+        f"default-mysql-server: {_candidate_line('default-mysql-server')}",
+    ]
     raise SystemExit(
-        "No supported DB server package found (mysql-server or mariadb-server). "
-        "Run 'apt-get update' or check apt sources."
+        "No supported DB server package found\n" + "\n".join(lines)
     )
 
 
@@ -55,3 +92,4 @@ PHP_EXTRAS = [
 ]
 APACHE_PKG = "apache2"
 CERTBOT_PKGS = ["certbot", "python3-certbot-apache"]
+

--- a/lampkitctl/system_ops.py
+++ b/lampkitctl/system_ops.py
@@ -13,6 +13,7 @@ from .packages import (
     PHP_BASE,
     PHP_EXTRAS,
     detect_db_engine,
+    refresh_cache,
 )
 from .utils import run_command
 
@@ -24,9 +25,11 @@ def install_lamp_stack(
     with_php: bool = True,
     with_certbot: bool = True,
     dry_run: bool = False,
+    no_recommends: bool = True,
 ):
     """Install Apache, a database engine and optional PHP/Certbot packages."""
 
+    refresh_cache(dry_run=dry_run)
     eng = detect_db_engine(preferred_engine)
     pkgs = [APACHE_PKG, eng.server_pkg]
     if with_php:
@@ -37,12 +40,11 @@ def install_lamp_stack(
         "install_lamp_stack",
         extra={"packages": pkgs, "db_engine": eng.name, "dry_run": dry_run},
     )
-    run_command(["apt-get", "update"], dry_run=dry_run, capture_output=True)
-    run_command(
-        ["apt-get", "install", "-y", *pkgs],
-        dry_run=dry_run,
-        capture_output=True,
-    )
+    install_cmd = ["apt-get", "install", "-y"]
+    if no_recommends:
+        install_cmd.append("--no-install-recommends")
+    install_cmd.extend(pkgs)
+    run_command(install_cmd, dry_run=dry_run, capture_output=True)
     return eng
 
 

--- a/lampkitctl/utils.py
+++ b/lampkitctl/utils.py
@@ -144,20 +144,21 @@ def classify_apt_error(e: subprocess.CalledProcessError) -> str:
     if has("unable to locate package") or has("has no installation candidate"):
         return (
             "APT failed: package not found.\n"
-            "- Verify the package name and your Ubuntu release.\n"
             "- Run: sudo apt-get update\n"
-            "- If you intended MySQL server, use 'mysql-server'; for MariaDB, use 'mariadb-server'."
+            "- Ensure your Ubuntu release is supported.\n"
+            "- If MySQL isn't available, try '--db-engine mariadb'."
         )
     if has("could not get lock") or has("unable to lock"):
         return (
             "APT is locked by another process.\n"
-            "- Close Software Updater/apt/dpkg, or wait for unattended-upgrades.\n"
-            "- Tip: ps aux | egrep 'apt|dpkg'"
+            "- Close apt/dpkg or wait for unattended-upgrades.\n"
+            "- Inspect: ps aux | egrep 'apt|dpkg'"
         )
     if has("temporary failure resolving"):
         return (
             "Network/DNS error while contacting mirrors.\n"
-            "- Check internet connectivity and DNS. Retry: sudo apt-get update"
+            "- Check internet connectivity and DNS.\n"
+            "- Retry: sudo apt-get update"
         )
     if e.returncode == 100 and has("permission denied"):
         return "APT failed due to permissions. Run with sudo or as root."

--- a/tests/test_install_lamp_cli.py
+++ b/tests/test_install_lamp_cli.py
@@ -9,6 +9,8 @@ def test_install_lamp_cli(monkeypatch):
     fake_engine = packages.Engine("mysql", "mysql-server", "mysql-client", "mysql")
     monkeypatch.setattr(system_ops, "detect_db_engine", lambda preferred: fake_engine)
 
+    monkeypatch.setattr(system_ops, "refresh_cache", lambda **k: calls.append("update"))
+
     def fake_run(cmd, dry_run=False, capture_output=False, **kwargs):
         calls.append(cmd)
         class R:

--- a/tests/test_install_lamp_stack.py
+++ b/tests/test_install_lamp_stack.py
@@ -1,0 +1,29 @@
+from lampkitctl import system_ops
+from lampkitctl.packages import Engine
+
+
+def test_update_before_detection(monkeypatch):
+    calls = []
+
+    def fake_refresh(**kwargs):
+        calls.append("update")
+
+    def fake_detect(preferred):
+        calls.append("detect")
+        return Engine("mysql", "mysql-server", "mysql-client", "mysql")
+
+    def fake_run(cmd, dry_run=False, capture_output=False):
+        calls.append(cmd)
+
+    monkeypatch.setattr(system_ops, "refresh_cache", fake_refresh)
+    monkeypatch.setattr(system_ops, "detect_db_engine", fake_detect)
+    monkeypatch.setattr(system_ops, "run_command", fake_run)
+
+    system_ops.install_lamp_stack(None, dry_run=True)
+
+    assert calls[0:2] == ["update", "detect"]
+    install_cmd = calls[2]
+    assert install_cmd[0:3] == ["apt-get", "install", "-y"]
+    assert "--no-install-recommends" in install_cmd
+    assert "mysql-server" in install_cmd
+

--- a/tests/test_preflight_lock_blocking.py
+++ b/tests/test_preflight_lock_blocking.py
@@ -1,0 +1,25 @@
+import subprocess
+
+from click.testing import CliRunner
+
+from lampkitctl import cli, preflight
+
+
+class Proc:
+    def __init__(self, stdout: str):
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = 0
+
+
+def test_apt_lock_blocks_install(monkeypatch):
+    def fake_run(cmd, capture_output=True, text=True):
+        return Proc("apt-get")
+
+    monkeypatch.setattr(preflight.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli.system_ops, "install_lamp_stack", lambda *a, **k: None)
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["install-lamp"])
+    assert result.exit_code == 2
+    assert "Preflight failed: package manager is busy" in result.output
+


### PR DESCRIPTION
## Summary
- block execution when apt/dpkg lock is detected
- refresh apt cache and reliably detect mysql/mariadb packages
- ensure menu install-lamp hands off to CLI and exits
- document DB auto-detection and apt lock behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3e6ba38483228d21677c4413b695