### PR TITLE
fix(site+wp): root-aware flows, /etc/hosts & /var/www guards, menu prompts; MariaDB socket auth; docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ or `--db-engine mariadb`.
 ### Create a site
 
 ```bash
-sudo lampkitctl create-site example.local \
+sudo "$(command -v lampkitctl)" create-site example.local \
   --doc-root /var/www/example.local \
   --db-name example_db \
   --db-user example_user \
@@ -314,6 +314,8 @@ menu                # Launch the interactive menu (if extras installed).
 * `--db-user <user>`
 * `--db-password <password>`
 * `--wordpress`
+* `--db-root-auth {auto,password,socket}`
+* `--db-root-pass <password>`
 
 
 ---

--- a/lampkitctl/db_ops.py
+++ b/lampkitctl/db_ops.py
@@ -2,11 +2,23 @@
 from __future__ import annotations
 
 import logging
+import subprocess
 from typing import Optional
 
 from .utils import run_command
 
 logger = logging.getLogger(__name__)
+
+
+def detect_engine() -> str:
+    """Return the installed database engine name (``mysql`` or ``mariadb``)."""
+
+    try:
+        p = subprocess.run(["mysql", "--version"], capture_output=True, text=True)
+    except OSError:
+        return "mysql"
+    out = (p.stdout or "") + (p.stderr or "")
+    return "mariadb" if "mariadb" in out.lower() else "mysql"
 
 
 def create_database_and_user(

--- a/lampkitctl/preflight.py
+++ b/lampkitctl/preflight.py
@@ -224,8 +224,7 @@ def checks_for(command: str, **kwargs) -> List[CheckResult]:
             apache_paths_present(),
             has_cmd("mysql", "MySQL not installed. Run: install-lamp."),
             has_cmd("php", "PHP not installed. Run: install-lamp."),
-            can_write("/etc/hosts"),
-            can_write("/var/www"),
+            is_root_or_sudo(),
             apt_lock(Severity.BLOCKING),
         ]
     if command == "uninstall-site":
@@ -233,13 +232,13 @@ def checks_for(command: str, **kwargs) -> List[CheckResult]:
             has_cmd("apache2", "Apache not installed. Run: install-lamp."),
             apache_paths_present(),
             has_cmd("mysql", "MySQL not installed. Run: install-lamp."),
-            can_write("/etc/hosts"),
-            can_write("/var/www"),
+            is_root_or_sudo(),
         ]
     if command == "wp-permissions":
         return [
             has_cmd("apache2", "Apache not installed. Run: install-lamp."),
             apache_paths_present(),
+            is_root_or_sudo(),
             path_exists(doc_root),
             is_wordpress_dir(doc_root),
             apt_lock(Severity.BLOCKING),

--- a/tests/test_cli_site_root_guard.py
+++ b/tests/test_cli_site_root_guard.py
@@ -1,0 +1,33 @@
+from click.testing import CliRunner
+
+from lampkitctl import cli
+
+
+def test_create_site_guard_invokes_sudo(monkeypatch):
+    called = {}
+
+    def fake_reexec(argv, non_interactive, dry_run):
+        called["argv"] = argv
+        raise SystemExit(1)
+
+    monkeypatch.setattr(cli, "maybe_reexec_with_sudo", fake_reexec)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "create-site",
+            "example.com",
+            "--doc-root",
+            "/var/www/example",
+            "--db-name",
+            "db",
+            "--db-user",
+            "user",
+            "--db-password",
+            "pw",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert called["argv"]

--- a/tests/test_db_auth_modes.py
+++ b/tests/test_db_auth_modes.py
@@ -1,0 +1,83 @@
+from click.testing import CliRunner
+
+from lampkitctl import cli, db_ops, system_ops, preflight
+
+
+def test_db_auth_modes(monkeypatch):
+    runner = CliRunner()
+
+    monkeypatch.setattr(cli.preflight, "ensure_or_fail", lambda *a, **k: None)
+    monkeypatch.setattr(cli.preflight, "apt_lock", lambda *a, **k: preflight.CheckResult(True, ""))
+    monkeypatch.setattr(system_ops, "create_web_directory", lambda *a, **k: None)
+    monkeypatch.setattr(system_ops, "create_virtualhost", lambda *a, **k: None)
+    monkeypatch.setattr(system_ops, "enable_site", lambda *a, **k: None)
+    monkeypatch.setattr(system_ops, "add_host_entry", lambda *a, **k: None)
+
+    captured = {}
+
+    def fake_create(db_name, user, pwd, root_password=None, dry_run=False):
+        captured["root"] = root_password
+
+    monkeypatch.setattr(db_ops, "create_database_and_user", fake_create)
+
+    monkeypatch.setattr(db_ops, "detect_engine", lambda: "mariadb")
+    runner.invoke(
+        cli.cli,
+        [
+            "--dry-run",
+            "create-site",
+            "example.com",
+            "--doc-root",
+            "/var/www/example",
+            "--db-name",
+            "db",
+            "--db-user",
+            "user",
+            "--db-password",
+            "pw",
+        ],
+    )
+    assert captured["root"] is None
+
+    monkeypatch.setattr(db_ops, "detect_engine", lambda: "mysql")
+    runner.invoke(
+        cli.cli,
+        [
+            "--dry-run",
+            "create-site",
+            "example.com",
+            "--doc-root",
+            "/var/www/example",
+            "--db-name",
+            "db",
+            "--db-user",
+            "user",
+            "--db-password",
+            "pw",
+            "--db-root-auth",
+            "password",
+            "--db-root-pass",
+            "rootpw",
+        ],
+    )
+    assert captured["root"] == "rootpw"
+
+    runner.invoke(
+        cli.cli,
+        [
+            "--dry-run",
+            "create-site",
+            "example.com",
+            "--doc-root",
+            "/var/www/example",
+            "--db-name",
+            "db",
+            "--db-user",
+            "user",
+            "--db-password",
+            "pw",
+            "--db-root-auth",
+            "socket",
+        ],
+    )
+    assert captured["root"] is None

--- a/tests/test_hosts_write.py
+++ b/tests/test_hosts_write.py
@@ -1,0 +1,15 @@
+from lampkitctl import system_ops
+
+
+def test_hosts_append_and_remove(tmp_path):
+    hosts = tmp_path / "hosts"
+    hosts.write_text("127.0.0.1 localhost\n", encoding="utf-8")
+    mode = hosts.stat().st_mode
+
+    system_ops.add_host_entry("example.com", hosts_file=str(hosts))
+    assert "example.com" in hosts.read_text(encoding="utf-8")
+    assert hosts.stat().st_mode == mode
+
+    system_ops.remove_host_entry("example.com", hosts_file=str(hosts))
+    assert "example.com" not in hosts.read_text(encoding="utf-8")
+    assert hosts.stat().st_mode == mode

--- a/tests/test_menu_resume_after_install.py
+++ b/tests/test_menu_resume_after_install.py
@@ -1,0 +1,30 @@
+from lampkitctl import menu
+
+
+def test_resume_after_install(monkeypatch):
+    calls = []
+
+    def fake_run_cli(args, dry_run=False):
+        calls.append(list(args))
+        if args[0] == "create-site" and len(calls) == 1:
+            return 1  # simulate preflight failure
+        return 0
+
+    monkeypatch.setattr(menu, "_run_cli", fake_run_cli)
+    select_iter = iter(["Create a site", "Exit"])
+    text_iter = iter(["example.com", "/var/www/example", "db", "user"])
+
+    monkeypatch.setattr(menu, "_select", lambda m, c: next(select_iter))
+    monkeypatch.setattr(menu, "_text", lambda m, default="": next(text_iter))
+    monkeypatch.setattr(menu, "_password", lambda m: "pw")
+
+    def fake_confirm(message, default=False):
+        return "install-lamp" in message
+
+    monkeypatch.setattr(menu, "_confirm", fake_confirm)
+
+    menu.run_menu(dry_run=False)
+
+    assert calls[0][0] == "create-site"
+    assert calls[1][0] == "install-lamp"
+    assert calls[2][0] == "create-site"

--- a/tests/test_menu_wp_permissions_prompt.py
+++ b/tests/test_menu_wp_permissions_prompt.py
@@ -1,0 +1,30 @@
+from lampkitctl import menu, preflight
+
+
+def test_wp_permissions_prompt_handles_defaults(monkeypatch):
+    monkeypatch.setattr(menu, "_text", lambda m, default="": "")
+    # Should exit without error even if empty string is returned
+    menu._wp_permissions_flow(dry_run=True)
+
+
+def test_wp_permissions_invalid_path_reprompt(monkeypatch, capsys):
+    responses = iter(["/bad", "/good"])
+    monkeypatch.setattr(menu, "_text", lambda m, default="": next(responses))
+
+    def fake_exists(path):
+        return preflight.CheckResult(path == "/good", "missing")
+
+    def fake_wp(path):
+        return preflight.CheckResult(path == "/good", "not wp")
+
+    monkeypatch.setattr(menu.preflight, "path_exists", fake_exists)
+    monkeypatch.setattr(menu.preflight, "is_wordpress_dir", fake_wp)
+
+    calls = []
+    monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: calls.append(args) or 0)
+
+    menu._wp_permissions_flow(dry_run=False)
+
+    out = capsys.readouterr().out
+    assert "missing" in out or "not wp" in out
+    assert calls == [["wp-permissions", "/good"]]


### PR DESCRIPTION
## Summary
- enforce root checks for site and WordPress flows and add DB root auth modes
- atomically manage /etc/hosts and set docroots to www-data with group handling
- improve menu to resume actions after install and validate WP paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0682627488322b723552edc84607d