### PR TITLE
fix(menu): create-site preflight + colored outputs; fix WP perms prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ Legacy: `python main.py --help` also works.
 ## Quick Start
 
 Commands run preflight checks and provide guidance if the environment is
-missing pieces.
+missing pieces. Informational output is color-coded: errors appear in **red**,
+warnings in **yellow**, and successes in **green**.
 
 ### Launch the interactive menu
 
@@ -193,6 +194,11 @@ sudo lampkitctl menu
 
 When elevation is required, the tool continues the chosen action after
 acquiring sudo; you do not need to re-select options.
+
+Choosing **Create a site** performs a LAMP preflight before asking for
+domain or database details. If Apache, MySQL, or PHP are missing, the menu
+offers to run `install-lamp` and resumes site creation once the installation
+completes.
 
 ### Install the LAMP stack
 
@@ -413,6 +419,10 @@ jobs:
 
 **Do I need sudo?**
 Yes—most operations (package install, `/etc` writes, services) require elevated privileges.
+
+**I see red or yellow messages**
+Colored output highlights problems (red) or warnings (yellow). Use the provided
+guidance to resolve issues before re-running commands.
 
 **`sudo lampkitctl` returns "command not found"**
 Some systems configure `sudo` with a *secure* `PATH` that omits your virtualenv. Install the global launcher so `sudo` can find the CLI:

--- a/lampkitctl/preflight.py
+++ b/lampkitctl/preflight.py
@@ -71,6 +71,19 @@ def has_cmd(
     return CheckResult(ok, msg or f"{name} not found. Install {name}.", severity)
 
 
+# Simple wrappers for common LAMP components
+def is_apache_installed() -> CheckResult:
+    return has_cmd("apache2", "Apache not installed. Run: install-lamp.")
+
+
+def is_mysql_installed() -> CheckResult:
+    return has_cmd("mysql", "MySQL not installed. Run: install-lamp.")
+
+
+def is_php_installed() -> CheckResult:
+    return has_cmd("php", "PHP not installed. Run: install-lamp.")
+
+
 def apache_paths_present() -> CheckResult:
     """Check for Apache configuration directories."""
 
@@ -82,7 +95,15 @@ def can_write(path: str) -> CheckResult:
     """Ensure the current user can write to ``path``."""
 
     ok = os.access(path, os.W_OK)
-    return CheckResult(ok, f"Cannot write {path}. Check permissions.")
+    if ok:
+        return CheckResult(True, "")
+    if path == "/etc/hosts":
+        msg = "Root required to modify /etc/hosts. Re-run with sudo."
+    elif path.startswith("/var/www"):
+        msg = "Root required to modify /var/www. Re-run with sudo."
+    else:
+        msg = f"Cannot write {path}. Check permissions."
+    return CheckResult(False, msg)
 
 
 from . import preflight_locks

--- a/lampkitctl/utils.py
+++ b/lampkitctl/utils.py
@@ -9,6 +9,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
 
+import click
+
 
 class JsonFormatter(logging.Formatter):
     """Format log records as JSON strings.
@@ -237,6 +239,27 @@ def echo_err(message: str) -> None:
     """Print ``message`` to standard error."""
 
     print(message, file=sys.stderr)
+
+
+# Colored output helpers
+def echo_error(msg: str) -> None:
+    click.secho(msg, fg="red", bold=True)
+
+
+def echo_warn(msg: str) -> None:
+    click.secho(msg, fg="yellow")
+
+
+def echo_info(msg: str) -> None:
+    click.secho(msg, fg="cyan")
+
+
+def echo_ok(msg: str) -> None:
+    click.secho(msg, fg="green")
+
+
+def echo_title(msg: str) -> None:
+    click.secho(msg, fg="magenta", bold=True)
 
 
 def is_non_interactive() -> bool:

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,0 +1,25 @@
+from lampkitctl import menu, utils
+
+
+def test_no_sites_found_color(monkeypatch):
+    monkeypatch.setattr(menu, "list_installed_sites", lambda: [])
+    calls = []
+
+    def fake_secho(msg, fg=None, bold=None, **kwargs):
+        calls.append((msg, fg, bold))
+
+    monkeypatch.setattr(utils.click, "secho", fake_secho)
+    menu._uninstall_site_flow(dry_run=True)
+    assert calls[0] == ("No sites found", "red", True)
+
+
+def test_no_domains_available_color(monkeypatch):
+    monkeypatch.setattr(menu, "list_installed_sites", lambda: [])
+    calls = []
+
+    def fake_secho(msg, fg=None, bold=None, **kwargs):
+        calls.append((msg, fg, bold))
+
+    monkeypatch.setattr(utils.click, "secho", fake_secho)
+    menu._generate_ssl_flow(dry_run=True)
+    assert calls[0] == ("No domains available", "red", True)

--- a/tests/test_menu_create_site_preflight.py
+++ b/tests/test_menu_create_site_preflight.py
@@ -1,0 +1,19 @@
+from lampkitctl import menu, preflight
+
+
+def test_create_site_preflight_blocks_prompts(monkeypatch):
+    monkeypatch.setattr(menu.preflight, "is_apache_installed", lambda: preflight.CheckResult(False, "no apache"))
+    monkeypatch.setattr(menu.preflight, "apache_paths_present", lambda: preflight.CheckResult(False, "no paths"))
+    monkeypatch.setattr(menu.preflight, "is_mysql_installed", lambda: preflight.CheckResult(False, "no mysql"))
+    monkeypatch.setattr(menu.preflight, "is_php_installed", lambda: preflight.CheckResult(False, "no php"))
+
+    confirms = []
+    texts = []
+
+    monkeypatch.setattr(menu, "_confirm", lambda m, default=False: confirms.append(m) or False)
+    monkeypatch.setattr(menu, "_text", lambda m, default="": texts.append(m) or "")
+
+    menu._create_site_flow(dry_run=True)
+
+    assert texts == []
+    assert confirms == ["Run install-lamp now?"]

--- a/tests/test_menu_resume_after_install.py
+++ b/tests/test_menu_resume_after_install.py
@@ -1,4 +1,4 @@
-from lampkitctl import menu
+from lampkitctl import menu, preflight
 
 
 def test_resume_after_install(monkeypatch):
@@ -11,6 +11,10 @@ def test_resume_after_install(monkeypatch):
         return 0
 
     monkeypatch.setattr(menu, "_run_cli", fake_run_cli)
+    monkeypatch.setattr(menu.preflight, "is_apache_installed", lambda: preflight.CheckResult(True, ""))
+    monkeypatch.setattr(menu.preflight, "apache_paths_present", lambda: preflight.CheckResult(True, ""))
+    monkeypatch.setattr(menu.preflight, "is_mysql_installed", lambda: preflight.CheckResult(True, ""))
+    monkeypatch.setattr(menu.preflight, "is_php_installed", lambda: preflight.CheckResult(True, ""))
     select_iter = iter(["Create a site", "Exit"])
     text_iter = iter(["example.com", "/var/www/example", "db", "user"])
 

--- a/tests/test_menu_wp_permissions_prompt.py
+++ b/tests/test_menu_wp_permissions_prompt.py
@@ -2,6 +2,8 @@ from lampkitctl import menu, preflight
 
 
 def test_wp_permissions_prompt_handles_defaults(monkeypatch):
+    monkeypatch.setattr(menu.preflight, "is_apache_installed", lambda: preflight.CheckResult(True, ""))
+    monkeypatch.setattr(menu.preflight, "apache_paths_present", lambda: preflight.CheckResult(True, ""))
     monkeypatch.setattr(menu, "_text", lambda m, default="": "")
     # Should exit without error even if empty string is returned
     menu._wp_permissions_flow(dry_run=True)
@@ -17,6 +19,8 @@ def test_wp_permissions_invalid_path_reprompt(monkeypatch, capsys):
     def fake_wp(path):
         return preflight.CheckResult(path == "/good", "not wp")
 
+    monkeypatch.setattr(menu.preflight, "is_apache_installed", lambda: preflight.CheckResult(True, ""))
+    monkeypatch.setattr(menu.preflight, "apache_paths_present", lambda: preflight.CheckResult(True, ""))
     monkeypatch.setattr(menu.preflight, "path_exists", fake_exists)
     monkeypatch.setattr(menu.preflight, "is_wordpress_dir", fake_wp)
 


### PR DESCRIPTION
## Summary
- preflight LAMP stack before prompting to create a site and resume after install
- add click-based color helpers and color key menu messages
- guard WP permissions with LAMP preflight and fix empty default prompt

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06cc7b2948322a1ddf23f6db939f5