### PR TITLE
feat(install): prompt & set DB root password (MySQL/MariaDB) + non-interactive options; mask secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,23 @@ sudo lampkitctl install-lamp --db-engine mariadb
 sudo lampkitctl install-lamp --db-engine auto --dry-run
 ```
 
+By default the installer prompts to set a **database root password**. For a
+non-interactive run supply the password via environment variable:
+
+```bash
+# interactive
+sudo "$(command -v lampkitctl)" install-lamp --db-engine auto
+
+# non-interactive
+export LAMPKITCTL_DB_ROOT_PASS='S3cure,Long,Unique!'
+sudo "$(command -v lampkitctl)" install-lamp --db-engine auto \
+     --db-root-pass-env LAMPKITCTL_DB_ROOT_PASS \
+     --db-root-plugin caching_sha2_password  # MySQL only, optional
+```
+
+> With MariaDB the installer switches root from socket-only to password
+> authentication.
+
 > **Note:** The install will abort if another apt/dpkg process holds the lock.
 > Wait for it to finish or close other package managers.
 

--- a/lampkitctl/menu.py
+++ b/lampkitctl/menu.py
@@ -444,7 +444,34 @@ def run_menu(dry_run: bool = False) -> None:
                 "--wait-apt-lock",
                 "120" if wait_choice else "0",
             ]
+            env_var = None
+            if not dry_run and _confirm(
+                "Main > Install LAMP server > Set database root password now?",
+                default=True,
+            ):
+                if engine_choice == "MariaDB":
+                    echo_info(
+                        "MariaDB: root will switch from socket to password authentication."
+                    )
+                while True:
+                    pw1 = _password(
+                        "Main > Install LAMP server > Database root password"
+                    )
+                    pw2 = _password(
+                        "Main > Install LAMP server > Confirm password"
+                    )
+                    if pw1 != pw2:
+                        echo_error("Passwords do not match")
+                        continue
+                    if len(pw1) < 12:
+                        echo_warn("Password shorter than 12 characters.")
+                    break
+                env_var = "LAMPKITCTL_MENU_DB_ROOT_PASS"
+                os.environ[env_var] = pw1
+                args.extend(["--db-root-pass-env", env_var])
             _run_cli(args, dry_run=dry_run)
+            if env_var:
+                os.environ.pop(env_var, None)
             return
         elif choice == "Create a site":
             _create_site_flow(dry_run=dry_run)

--- a/lampkitctl/utils.py
+++ b/lampkitctl/utils.py
@@ -89,6 +89,14 @@ def setup_logging(level: int = logging.INFO) -> None:
 
 logger = logging.getLogger(__name__)
 
+SECRET_PLACEHOLDER = "****"
+
+
+def mask_secret(s: str | None) -> str:
+    """Return ``SECRET_PLACEHOLDER`` when ``s`` is truthy."""
+
+    return SECRET_PLACEHOLDER if s else ""
+
 
 def run_command(
     cmd: List[str],
@@ -97,6 +105,7 @@ def run_command(
     log_cmd: Optional[Iterable[str]] = None,
     capture_output: bool = False,
     text: bool = True,
+    input_text: str | None = None,
     **kwargs,
 ) -> subprocess.CompletedProcess:
     """Execute a system command with logging and optional dry run.
@@ -129,6 +138,7 @@ def run_command(
             check=check,
             capture_output=capture_output,
             text=text,
+            input=input_text,
             **kwargs,
         )
     except subprocess.CalledProcessError as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def test_cli_install_lamp(monkeypatch) -> None:
     monkeypatch.setattr(cli.system_ops, "install_lamp_stack", fake_install)
     runner = CliRunner()
     result = runner.invoke(
-        cli.cli, ["--dry-run", "install-lamp", "--db-engine", "mariadb"]
+        cli.cli, ["--dry-run", "install-lamp", "--db-engine", "mariadb"], input="n\n"
     )
     assert result.exit_code == 0
     assert calls == ["mariadb"]

--- a/tests/test_db_set_root_password_mariadb.py
+++ b/tests/test_db_set_root_password_mariadb.py
@@ -1,0 +1,13 @@
+from lampkitctl import db_ops
+
+
+def test_mariadb_sql(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, dry_run=False, input_text=None, **kwargs):
+        captured['sql'] = input_text
+
+    monkeypatch.setattr(db_ops, 'run_command', fake_run)
+    db_ops.set_root_password('mariadb', 'pw', dry_run=True)
+    assert 'IDENTIFIED VIA mysql_native_password' in captured['sql']
+    assert 'pw' in captured['sql']

--- a/tests/test_db_set_root_password_mysql.py
+++ b/tests/test_db_set_root_password_mysql.py
@@ -1,0 +1,15 @@
+from lampkitctl import db_ops
+
+
+def test_mysql_plugin_sql(monkeypatch):
+    recorded = {}
+
+    def fake_run(cmd, dry_run=False, input_text=None, **kwargs):
+        recorded['cmd'] = cmd
+        recorded['sql'] = input_text
+
+    monkeypatch.setattr(db_ops, 'run_command', fake_run)
+    db_ops.set_root_password('mysql', 'pw', 'caching_sha2_password', dry_run=True)
+    assert 'mysql --protocol=socket -u root' in ' '.join(recorded['cmd'])
+    assert 'caching_sha2_password' in recorded['sql']
+    assert 'pw' in recorded['sql']

--- a/tests/test_install_flow_root_pass.py
+++ b/tests/test_install_flow_root_pass.py
@@ -1,0 +1,95 @@
+import logging
+from click.testing import CliRunner
+
+from lampkitctl import cli, db_ops, packages, system_ops
+from lampkitctl import preflight, preflight_locks, utils
+
+
+def _setup_common(monkeypatch, calls):
+    monkeypatch.setattr(cli.preflight, "ensure_or_fail", lambda *a, **k: None)
+    monkeypatch.setattr(
+        cli.preflight_locks, "wait_for_lock", lambda *a, **k: preflight_locks.LockInfo(False)
+    )
+    monkeypatch.setattr(
+        cli.preflight_locks, "detect_lock", lambda: preflight_locks.LockInfo(False)
+    )
+    fake_engine = packages.Engine("mysql", "mysql-server", "mysql-client", "mysql")
+    monkeypatch.setattr(system_ops, "install_lamp_stack", lambda *a, **k: fake_engine)
+    monkeypatch.setattr(system_ops, "ensure_db_ready", lambda **k: True)
+    monkeypatch.setattr(cli.utils, "setup_logging", lambda *a, **k: None)
+
+    def fake_set(engine, password, plugin, dry_run=False):
+        calls.append((engine, password, plugin, dry_run))
+
+    monkeypatch.setattr(db_ops, "set_root_password", fake_set)
+
+
+def test_interactive_flow(monkeypatch):
+    calls = []
+    _setup_common(monkeypatch, calls)
+    runner = CliRunner()
+    pw = "supersecretpw1"
+    result = runner.invoke(
+        cli.cli,
+        ["--dry-run", "install-lamp"],
+        input=f"y\n{pw}\n{pw}\n",
+    )
+    assert result.exit_code == 0
+    assert calls[0][1] == pw
+
+
+def test_non_interactive_env(monkeypatch):
+    calls = []
+    _setup_common(monkeypatch, calls)
+    runner = CliRunner()
+    env = {"MY_PW": "supersecretpw2"}
+    result = runner.invoke(
+        cli.cli,
+        [
+            "--dry-run",
+            "--non-interactive",
+            "install-lamp",
+            "--db-root-pass-env",
+            "MY_PW",
+            "--db-root-plugin",
+            "mysql_native_password",
+        ],
+        env=env,
+    )
+    assert result.exit_code == 0
+    assert calls[0][1] == "supersecretpw2"
+    assert calls[0][2] == "mysql_native_password"
+
+
+def test_non_interactive_no_pass(monkeypatch):
+    calls = []
+    _setup_common(monkeypatch, calls)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli, ["--dry-run", "--non-interactive", "install-lamp"]
+    )
+    assert result.exit_code == 0
+    assert not calls
+    assert "Skipping database root password" in result.output
+
+
+def test_masking(monkeypatch, caplog):
+    calls = []
+    _setup_common(monkeypatch, calls)
+    caplog.set_level(logging.INFO)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "--dry-run",
+            "install-lamp",
+            "--set-db-root-pass",
+            "--db-root-pass",
+            "supersecretpw3",
+        ],
+    )
+    assert result.exit_code == 0
+    assert any(
+        getattr(r, "db_root_pass", None) == utils.SECRET_PLACEHOLDER
+        for r in caplog.records
+    )

--- a/tests/test_install_lamp_cli.py
+++ b/tests/test_install_lamp_cli.py
@@ -23,7 +23,7 @@ def test_install_lamp_cli(monkeypatch):
     monkeypatch.setattr(system_ops, "run_command", fake_run)
     monkeypatch.setattr(system_ops.preflight_locks, "detect_lock", lambda: preflight_locks.LockInfo(False))
     runner = CliRunner()
-    result = runner.invoke(cli.cli, ["--dry-run", "install-lamp"])
+    result = runner.invoke(cli.cli, ["--dry-run", "install-lamp"], input="n\n")
     assert result.exit_code == 0
     install_cmd = calls[1]
     assert "mysql-server" in install_cmd

--- a/tests/test_menu_guards.py
+++ b/tests/test_menu_guards.py
@@ -7,6 +7,7 @@ def test_menu_install_lamp_blocking(monkeypatch, capsys):
     sequence = iter(["Install LAMP server", "Auto", "Exit"])
     monkeypatch.setattr(menu, "_select", lambda msg, choices: next(sequence))
     monkeypatch.setattr(menu, "_confirm", lambda msg, default=True: True)
+    monkeypatch.setattr(menu, "_password", lambda m: "pw")
 
     def fake_run_cli(args, dry_run=False):
         print("Preflight failed", file=sys.stderr)

--- a/tests/test_menu_resume.py
+++ b/tests/test_menu_resume.py
@@ -18,6 +18,7 @@ def test_menu_install_lamp_uses_sudo(monkeypatch):
     responses = iter(["Install LAMP server", "MySQL"])
     monkeypatch.setattr(menu, "_select", lambda message, choices: next(responses))
     monkeypatch.setattr(menu, "_confirm", lambda message, default=True: True)
+    monkeypatch.setattr(menu, "_password", lambda m: "pw")
 
     menu.run_menu(dry_run=False)
 
@@ -29,6 +30,8 @@ def test_menu_install_lamp_uses_sudo(monkeypatch):
         "mysql",
         "--wait-apt-lock",
         "120",
+        "--db-root-pass-env",
+        "LAMPKITCTL_MENU_DB_ROOT_PASS",
     ]
 
 


### PR DESCRIPTION
## Summary
- add secret masking helper and stdin-based SQL execution
- prompt for DB root password during install with optional env/file inputs
- menu and README updated, cover MySQL/MariaDB root password setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0b7538c7c8322804a6acee726fc65