### PR TITLE
fix(installer): self‑test uses version; launcher passes args cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ warnings in **yellow**, and successes in **green**.
 
 ```bash
 lampkitctl install-launcher  # run once to enable sudo lampkitctl
+lampkitctl version          # verify CLI is working
 sudo lampkitctl menu
 ```
 

--- a/scripts/install-lampkitctl.sh
+++ b/scripts/install-lampkitctl.sh
@@ -148,7 +148,7 @@ if [ "$INSTALL_LAUNCHER" -eq 1 ]; then
   note "Installing global launcher at $LAUNCHER"
   sudo tee "$LAUNCHER" >/dev/null <<LAUNCH
 #!/usr/bin/env bash
-exec "$DIR/.venv/bin/lampkitctl" "${1:+$@}"
+exec "$DIR/.venv/bin/lampkitctl" "\$@"
 LAUNCH
   sudo chmod +x "$LAUNCHER"
 fi
@@ -157,9 +157,12 @@ fi
 # Self-test
 # -----------------------------
 ok "Running self-test…"
-run_as_target "'$DIR/.venv/bin/lampkitctl' --version || true"
+run_as_target "'$DIR/.venv/bin/lampkitctl' version || true"
+run_as_target "'$DIR/.venv/bin/lampkitctl' --help >/dev/null || true"
+
 if command -v lampkitctl >/dev/null 2>&1; then
-  sudo lampkitctl --version || true
+  sudo lampkitctl version || true
+  sudo lampkitctl --help >/dev/null || true
 else
   warn "Global 'lampkitctl' not in PATH yet (no launcher?). You can run: $DIR/.venv/bin/lampkitctl"
 fi


### PR DESCRIPTION
## Summary
- run self-test with `version` subcommand and help checks
- write launcher with clean `$@` passthrough
- document `lampkitctl version` usage in README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3006896488322ad86cba879e65596