### PR TITLE
fix(wp): extract into docroot (no nested folder); remove tarball; apply perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ sudo "$(command -v lampkitctl)" create-site example.local \
 > If you omit options, the CLI may prompt for required values.
 > Use `--dry-run` to preview actions without changing the system.
 
+When `--with-wordpress` is enabled, WordPress files are extracted **directly into the document root** (no nested `wordpress/` folder). The downloaded archive is deleted after extraction.
+
 ### Issue an SSL certificate (Certbot)
 
 ```bash

--- a/tests/test_wp_install_docroot.py
+++ b/tests/test_wp_install_docroot.py
@@ -1,0 +1,37 @@
+import lampkitctl.wp_ops as wp_ops
+
+
+def test_install_wordpress_extracts_into_docroot(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(cmd, dry_run=False, **kwargs):
+        calls.append(cmd)
+
+    monkeypatch.setattr(wp_ops, "run_command", fake_run)
+    wp_ops.install_wordpress(str(tmp_path), "db", "user", "pw", dry_run=True)
+
+    wget_cmd, tar_cmd, rm_cmd, chown_cmd, find_dir_cmd, find_file_cmd = calls
+    assert "--strip-components=1" in tar_cmd
+    assert str(tmp_path) in tar_cmd
+    assert rm_cmd[0] == "rm" and rm_cmd[1] == "-f" and rm_cmd[2].startswith("/tmp/wordpress-")
+    assert chown_cmd[:3] == ["chown", "-R", "www-data:www-data"]
+    assert find_dir_cmd[:3] == ["find", str(tmp_path), "-type"]
+    assert find_file_cmd[:3] == ["find", str(tmp_path), "-type"]
+
+
+def test_install_wordpress_skips_when_config_present(monkeypatch, tmp_path):
+    (tmp_path / "wp-config.php").write_text("")
+    calls = []
+    warns = []
+
+    def fake_run(cmd, dry_run=False, **kwargs):
+        calls.append(cmd)
+
+    monkeypatch.setattr(wp_ops, "run_command", fake_run)
+    monkeypatch.setattr(wp_ops, "echo_warn", lambda msg: warns.append(msg))
+    wp_ops.install_wordpress(str(tmp_path), "db", "user", "pw", dry_run=True)
+
+    # Only permission commands should run
+    assert all(cmd[0] != "wget" for cmd in calls)
+    assert warns and "WordPress appears to be installed" in warns[0]
+    assert len(calls) == 3  # chown + two find commands


### PR DESCRIPTION
## Summary
- install WordPress files directly into the chosen document root and delete the downloaded archive
- warn and skip extraction when WordPress already exists, still applying secure permissions
- document direct-to-docroot WordPress extraction behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a48737c81c83229cc70f23434d9376