### PR TITLE
feat(tui): DB picker with WordPress auto-detect from wp-config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ completes.
 
 In the menu, **Set WordPress permissions**, **Uninstall site**, and **Generate SSL certificate** now present a list of detected Apache vhosts to choose from. The tool reads `ServerName` and `DocumentRoot` from `/etc/apache2/sites-available/*.conf`.
 
+When uninstalling a site, the menu now presents a **database picker** listing local MySQL/MariaDB databases. If the selected site is a WordPress install and `wp-config.php` declares a database that exists on the server, that database is **pre-selected**.
+
 ### Install the LAMP stack
 
 ```bash

--- a/lampkitctl/db_introspect.py
+++ b/lampkitctl/db_introspect.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable
+import os, re, subprocess
+
+SYSTEM_SCHEMAS = {"information_schema", "mysql", "performance_schema", "sys"}
+
+@dataclass
+class DBList:
+    databases: list[str]
+
+# Use local socket root by default, avoid echoing creds; allow password via env
+# LAMPKITCTL_DB_ROOT_PASS (string) when root requires password.
+
+def _mysql_cmd() -> list[str]:
+    return ["mysql", "--protocol=socket", "-u", "root", "-N", "-B"]
+
+
+def list_databases() -> DBList:
+    cmd = _mysql_cmd() + ["-e", "SHOW DATABASES"]
+    env = os.environ.copy()
+    password = env.get("LAMPKITCTL_DB_ROOT_PASS")
+    if password:
+        env["MYSQL_PWD"] = password  # avoid -p in argv
+    out = subprocess.check_output(cmd, env=env, text=True)
+    names = [ln.strip() for ln in out.splitlines() if ln.strip()]
+    names = [n for n in names if n not in SYSTEM_SCHEMAS]
+    names.sort()
+    return DBList(names)
+
+WP_DB_NAME_RE = re.compile(r"define\(\s*['\"]DB_NAME['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
+WP_DB_USER_RE = re.compile(r"define\(\s*['\"]DB_USER['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
+WP_DB_HOST_RE = re.compile(r"define\(\s*['\"]DB_HOST['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
+# Optional: table prefix
+WP_TABLE_PREFIX_RE = re.compile(r"^\s*\$table_prefix\s*=\s*['\"]([^'\"]+)['\"];", re.MULTILINE)
+
+@dataclass
+class WPConfig:
+    name: str | None
+    user: str | None
+    host: str | None
+    table_prefix: str | None
+
+def parse_wp_config(docroot: str) -> WPConfig | None:
+    path = os.path.join(docroot, "wp-config.php")
+    if not os.path.exists(path):
+        return None
+    try:
+        data = open(path, "r", encoding="utf-8", errors="ignore").read()
+    except Exception:
+        return None
+    name = (WP_DB_NAME_RE.search(data) or [None, None])[1]
+    user = (WP_DB_USER_RE.search(data) or [None, None])[1]
+    host = (WP_DB_HOST_RE.search(data) or [None, None])[1]
+    pref_m = WP_TABLE_PREFIX_RE.search(data)
+    prefix = pref_m.group(1) if pref_m else None
+    return WPConfig(name, user, host, prefix)

--- a/tests/test_db_list_filters_system.py
+++ b/tests/test_db_list_filters_system.py
@@ -1,0 +1,10 @@
+from lampkitctl import db_introspect
+
+
+def test_filters_system(monkeypatch):
+    def fake_check_output(cmd, env=None, text=None):
+        return "mysql\ninformation_schema\ncustom1\nperformance_schema\nsys\nmydb\n"
+
+    monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
+    dblist = db_introspect.list_databases()
+    assert dblist.databases == ["custom1", "mydb"]

--- a/tests/test_menu_db_picker_preselect.py
+++ b/tests/test_menu_db_picker_preselect.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+from lampkitctl import menu, apache_vhosts, db_introspect
+
+
+def make_vhost(domain, docroot):
+    return apache_vhosts.VHost(domain, docroot, "/etc/apache2/sites-available/a.conf", False)
+
+
+def test_db_picker_preselects_wp_db(monkeypatch):
+    vhost = make_vhost("a.com", "/a")
+    monkeypatch.setattr(menu, "_choose_site", lambda: vhost)
+    monkeypatch.setattr(
+        menu.db_introspect,
+        "list_databases",
+        lambda: db_introspect.DBList(["wpdb", "other"]),
+    )
+    monkeypatch.setattr(
+        menu.db_introspect,
+        "parse_wp_config",
+        lambda path: db_introspect.WPConfig("wpdb", None, None, None),
+    )
+
+    def fake_select(message=None, choices=None, default=None):
+        fake_select.default = default
+        class R:
+            def execute(self):
+                return default
+        return R()
+
+    menu.inquirer = SimpleNamespace(select=fake_select, text=lambda **k: None)
+    monkeypatch.setattr(menu, "_text", lambda *a, **k: "dbuser")
+    monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
+    calls = []
+    monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: calls.append(args) or 0)
+    menu._uninstall_site_flow(dry_run=False)
+    assert calls == [[
+        "uninstall-site",
+        "a.com",
+        "--doc-root",
+        "/a",
+        "--db-name",
+        "wpdb",
+        "--db-user",
+        "dbuser",
+    ]]
+    assert fake_select.default == "wpdb"
+
+
+def test_db_picker_warns_missing_wp_db(monkeypatch):
+    vhost = make_vhost("a.com", "/a")
+    monkeypatch.setattr(menu, "_choose_site", lambda: vhost)
+    monkeypatch.setattr(
+        menu.db_introspect,
+        "list_databases",
+        lambda: db_introspect.DBList(["alpha", "beta"]),
+    )
+    monkeypatch.setattr(
+        menu.db_introspect,
+        "parse_wp_config",
+        lambda path: db_introspect.WPConfig("missing", None, None, None),
+    )
+    warns = []
+    monkeypatch.setattr(menu, "echo_warn", lambda msg: warns.append(msg))
+
+    def fake_select(message=None, choices=None, default=None):
+        fake_select.default = default
+        class R:
+            def execute(self):
+                return default
+        return R()
+
+    menu.inquirer = SimpleNamespace(select=fake_select, text=lambda **k: None)
+    monkeypatch.setattr(menu, "_text", lambda *a, **k: "dbuser")
+    monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
+    calls = []
+    monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: calls.append(args) or 0)
+    menu._uninstall_site_flow(dry_run=False)
+    assert calls == [[
+        "uninstall-site",
+        "a.com",
+        "--doc-root",
+        "/a",
+        "--db-name",
+        "alpha",
+        "--db-user",
+        "dbuser",
+    ]]
+    assert fake_select.default == "alpha"
+    assert warns == ["DB from wp-config.php not found on server: missing"]

--- a/tests/test_menu_site_selection.py
+++ b/tests/test_menu_site_selection.py
@@ -28,7 +28,8 @@ def test_uninstall_site_uses_selected_domain(monkeypatch):
     monkeypatch.setattr(menu, "inquirer", None)
     inputs = iter(["1"])  # select first site
     monkeypatch.setattr(menu, "input", lambda _: next(inputs), raising=False)
-    texts = iter(["dbname", "dbuser"])
+    monkeypatch.setattr(menu, "_choose_database", lambda doc_root: "dbname")
+    texts = iter(["dbuser"])
     monkeypatch.setattr(menu, "_text", lambda *a, **k: next(texts))
     monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
     calls = []

--- a/tests/test_parse_wp_config.py
+++ b/tests/test_parse_wp_config.py
@@ -1,0 +1,21 @@
+from lampkitctl.db_introspect import parse_wp_config
+
+
+WP_SAMPLE = """
+<?php
+define('DB_NAME', 'mydb');
+define('DB_USER', 'myuser');
+define('DB_HOST', 'localhost');
+$table_prefix = 'wp_';
+"""
+
+
+def test_parse_wp_config(tmp_path):
+    cfg_file = tmp_path / "wp-config.php"
+    cfg_file.write_text(WP_SAMPLE)
+    cfg = parse_wp_config(str(tmp_path))
+    assert cfg is not None
+    assert cfg.name == "mydb"
+    assert cfg.user == "myuser"
+    assert cfg.host == "localhost"
+    assert cfg.table_prefix == "wp_"


### PR DESCRIPTION
## Summary
- add db_introspect helper for listing databases and parsing wp-config.php
- enhance uninstall flow with database picker and WordPress DB preselection
- document database picker and add unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a49ff24da48322ac2cd653029c6efd