### PR TITLE
feat(tui): DB picker prompts for root password when required (env fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ In the menu, **Set WordPress permissions**, **Uninstall site**, and **Generate S
 
 When uninstalling a site, the menu now presents a **database picker** listing local MySQL/MariaDB databases. If the selected site is a WordPress install and `wp-config.php` declares a database that exists on the server, that database is **pre-selected**.
 
+**Database picker**: If your local MySQL/MariaDB root requires a password, the TUI will prompt for it (masked) and retry the listing. For non-interactive use, set an environment variable before launching the menu:
+
+```bash
+export LAMPKITCTL_DB_ROOT_PASS='your-root-password'
+lampkitctl menu
+```
+
+The password is not logged and is not stored on disk. It is kept in memory for the session only.
+
 ### Install the LAMP stack
 
 ```bash

--- a/lampkitctl/db_introspect.py
+++ b/lampkitctl/db_introspect.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Optional
 import os, re, subprocess
 
 SYSTEM_SCHEMAS = {"information_schema", "mysql", "performance_schema", "sys"}
+
+# Cached password for the session (process lifetime only)
+_CACHED_ROOT_PASSWORD: Optional[str] = None
 
 @dataclass
 class DBList:
@@ -16,17 +19,33 @@ def _mysql_cmd() -> list[str]:
     return ["mysql", "--protocol=socket", "-u", "root", "-N", "-B"]
 
 
-def list_databases() -> DBList:
-    cmd = _mysql_cmd() + ["-e", "SHOW DATABASES"]
+def _mysql_env(password: Optional[str]):
     env = os.environ.copy()
-    password = env.get("LAMPKITCTL_DB_ROOT_PASS")
-    if password:
-        env["MYSQL_PWD"] = password  # avoid -p in argv
-    out = subprocess.check_output(cmd, env=env, text=True)
+    pwd = password or env.get("LAMPKITCTL_DB_ROOT_PASS") or _CACHED_ROOT_PASSWORD
+    if pwd:
+        env["MYSQL_PWD"] = pwd  # avoid -p in argv
+    return env
+
+
+def list_databases(password: Optional[str] = None) -> DBList:
+    cmd = _mysql_cmd() + ["-e", "SHOW DATABASES"]
+    out = subprocess.check_output(
+        cmd,
+        env=_mysql_env(password),
+        text=True,
+        stderr=subprocess.STDOUT,
+    )
     names = [ln.strip() for ln in out.splitlines() if ln.strip()]
     names = [n for n in names if n not in SYSTEM_SCHEMAS]
     names.sort()
     return DBList(names)
+
+
+def is_access_denied(exc: subprocess.CalledProcessError, stderr: str | None) -> bool:
+    """Detect MySQL access denied errors from stderr/output."""
+    text = " ".join(filter(None, [stderr, getattr(exc, "output", None), str(exc)]))
+    text = text.lower()
+    return "access denied" in text or "1698" in text or "28000" in text
 
 WP_DB_NAME_RE = re.compile(r"define\(\s*['\"]DB_NAME['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
 WP_DB_USER_RE = re.compile(r"define\(\s*['\"]DB_USER['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")

--- a/tests/test_db_list_auth_flow.py
+++ b/tests/test_db_list_auth_flow.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+import subprocess
+from lampkitctl import menu, db_introspect
+
+def test_db_list_auth_flow(monkeypatch):
+    # reset cache
+    db_introspect._CACHED_ROOT_PASSWORD = None
+    env_calls = []
+
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
+        env_calls.append(env.get("MYSQL_PWD"))
+        if len(env_calls) == 1:
+            raise subprocess.CalledProcessError(
+                1, cmd, output="ERROR 1698 (28000): Access denied")
+        return "alpha\nbeta\n"
+
+    monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
+
+    secrets = []
+
+    def fake_secret(message):
+        secrets.append(message)
+        class R:
+            def execute(self):
+                return "pw"
+        return R()
+
+    menu.inquirer = SimpleNamespace(secret=fake_secret)
+
+    dblist = menu._list_dbs_interactive()
+    assert dblist == ["alpha", "beta"]
+    assert secrets == ["Database root password:"]
+    assert env_calls == [None, "pw"]

--- a/tests/test_db_list_env_var.py
+++ b/tests/test_db_list_env_var.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from lampkitctl import menu, db_introspect
+
+def test_db_list_env_var(monkeypatch):
+    db_introspect._CACHED_ROOT_PASSWORD = None
+    monkeypatch.setenv("LAMPKITCTL_DB_ROOT_PASS", "pw")
+    env_calls = []
+
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
+        env_calls.append(env.get("MYSQL_PWD"))
+        return "mydb\n"
+
+    monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
+
+    def fake_secret(message):
+        raise AssertionError("prompt should not be called")
+
+    menu.inquirer = SimpleNamespace(secret=fake_secret)
+
+    dblist = menu._list_dbs_interactive()
+    assert dblist == ["mydb"]
+    assert env_calls == ["pw"]

--- a/tests/test_db_list_filters_system.py
+++ b/tests/test_db_list_filters_system.py
@@ -2,7 +2,7 @@ from lampkitctl import db_introspect
 
 
 def test_filters_system(monkeypatch):
-    def fake_check_output(cmd, env=None, text=None):
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
         return "mysql\ninformation_schema\ncustom1\nperformance_schema\nsys\nmydb\n"
 
     monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)


### PR DESCRIPTION
## Summary
- handle MySQL root password via env/cache and detect access denied errors
- prompt once in TUI DB picker and reuse password for session
- document environment variable, add tests for password prompt and env override

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4abea19b08322abe14596e3b56d93