### PR TITLE
feat(tui/db): robust DB listing fallbacks (socket→TCP→sudo defaults-file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ In the menu, **Set WordPress permissions**, **Uninstall site**, and **Generate S
 
 When uninstalling a site, the menu now presents a **database picker** listing local MySQL/MariaDB databases. If the selected site is a WordPress install and `wp-config.php` declares a database that exists on the server, that database is **pre-selected**.
 
-**Database picker**: If your local MySQL/MariaDB root requires a password, the TUI will prompt for it (masked) and retry the listing. For non-interactive use, set an environment variable before launching the menu:
+**Database picker**: The menu automatically tries multiple strategies to list databases: socket, TCP to `127.0.0.1`, and sudo fallbacks (including Debian maintenance credentials). If all fail, it falls back to manual database entry. To avoid interactive prompts, set an environment variable before launching the menu:
 
 ```bash
 export LAMPKITCTL_DB_ROOT_PASS='your-root-password'

--- a/lampkitctl/db_introspect.py
+++ b/lampkitctl/db_introspect.py
@@ -1,51 +1,105 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Iterable, Optional
-import os, re, subprocess
+from typing import Optional
+import os, re, subprocess, shlex
 
 SYSTEM_SCHEMAS = {"information_schema", "mysql", "performance_schema", "sys"}
 
 # Cached password for the session (process lifetime only)
 _CACHED_ROOT_PASSWORD: Optional[str] = None
 
+
 @dataclass
 class DBList:
     databases: list[str]
 
-# Use local socket root by default, avoid echoing creds; allow password via env
-# LAMPKITCTL_DB_ROOT_PASS (string) when root requires password.
 
-def _mysql_cmd() -> list[str]:
-    return ["mysql", "--protocol=socket", "-u", "root", "-N", "-B"]
-
-
-def _mysql_env(password: Optional[str]):
+def _env_with_pwd(pwd: Optional[str]) -> dict:
     env = os.environ.copy()
-    pwd = password or env.get("LAMPKITCTL_DB_ROOT_PASS") or _CACHED_ROOT_PASSWORD
-    if pwd:
-        env["MYSQL_PWD"] = pwd  # avoid -p in argv
+    p = pwd or env.get("LAMPKITCTL_DB_ROOT_PASS") or _CACHED_ROOT_PASSWORD
+    if p:
+        env["MYSQL_PWD"] = p
     return env
 
 
+class DBListError(RuntimeError):
+    pass
+
+
+_ATTEMPTS = (
+    ["mysql", "--protocol=socket", "-u", "root", "-N", "-B", "-e", "SHOW DATABASES"],
+    [
+        "mysql",
+        "-h",
+        "127.0.0.1",
+        "-P",
+        "3306",
+        "-u",
+        "root",
+        "-N",
+        "-B",
+        "-e",
+        "SHOW DATABASES",
+    ],
+)
+
+
+_SUDO_ATTEMPTS = (
+    [
+        "sudo",
+        "-n",
+        "mysql",
+        "--protocol=socket",
+        "-u",
+        "root",
+        "-N",
+        "-B",
+        "-e",
+        "SHOW DATABASES",
+    ],
+    [
+        "sudo",
+        "-n",
+        "mysql",
+        "--defaults-file=/etc/mysql/debian.cnf",
+        "-N",
+        "-B",
+        "-e",
+        "SHOW DATABASES",
+    ],
+)
+
+
 def list_databases(password: Optional[str] = None) -> DBList:
-    cmd = _mysql_cmd() + ["-e", "SHOW DATABASES"]
-    out = subprocess.check_output(
-        cmd,
-        env=_mysql_env(password),
-        text=True,
-        stderr=subprocess.STDOUT,
-    )
-    names = [ln.strip() for ln in out.splitlines() if ln.strip()]
-    names = [n for n in names if n not in SYSTEM_SCHEMAS]
-    names.sort()
-    return DBList(names)
+    env = _env_with_pwd(password)
+    last_err: Optional[Exception] = None
+
+    for cmd in _ATTEMPTS:
+        try:
+            out = subprocess.check_output(cmd, env=env, text=True, stderr=subprocess.STDOUT)
+            names = [ln.strip() for ln in out.splitlines() if ln.strip()]
+            names = [n for n in names if n not in SYSTEM_SCHEMAS]
+            names.sort()
+            return DBList(names)
+        except Exception as exc:  # pragma: no cover - error path
+            last_err = exc
+
+    for cmd in _SUDO_ATTEMPTS:
+        try:
+            out = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
+            names = [ln.strip() for ln in out.splitlines() if ln.strip()]
+            names = [n for n in names if n not in SYSTEM_SCHEMAS]
+            names.sort()
+            return DBList(names)
+        except Exception as exc:  # pragma: no cover - error path
+            last_err = exc
+
+    raise DBListError(str(last_err) if last_err else "Unknown DB list error")
 
 
-def is_access_denied(exc: subprocess.CalledProcessError, stderr: str | None) -> bool:
-    """Detect MySQL access denied errors from stderr/output."""
-    text = " ".join(filter(None, [stderr, getattr(exc, "output", None), str(exc)]))
-    text = text.lower()
-    return "access denied" in text or "1698" in text or "28000" in text
+def cache_root_password(pwd: str) -> None:
+    global _CACHED_ROOT_PASSWORD
+    _CACHED_ROOT_PASSWORD = pwd
 
 WP_DB_NAME_RE = re.compile(r"define\(\s*['\"]DB_NAME['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
 WP_DB_USER_RE = re.compile(r"define\(\s*['\"]DB_USER['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")

--- a/tests/test_db_list_auth_flow.py
+++ b/tests/test_db_list_auth_flow.py
@@ -2,17 +2,16 @@ from types import SimpleNamespace
 import subprocess
 from lampkitctl import menu, db_introspect
 
+
 def test_db_list_auth_flow(monkeypatch):
-    # reset cache
     db_introspect._CACHED_ROOT_PASSWORD = None
     env_calls = []
 
     def fake_check_output(cmd, env=None, text=None, stderr=None):
-        env_calls.append(env.get("MYSQL_PWD"))
-        if len(env_calls) == 1:
-            raise subprocess.CalledProcessError(
-                1, cmd, output="ERROR 1698 (28000): Access denied")
-        return "alpha\nbeta\n"
+        env_calls.append(env.get("MYSQL_PWD") if env else None)
+        if env and env.get("MYSQL_PWD") == "pw":
+            return "alpha\nbeta\n"
+        raise subprocess.CalledProcessError(1, cmd, output="ERROR")
 
     monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
 
@@ -20,9 +19,11 @@ def test_db_list_auth_flow(monkeypatch):
 
     def fake_secret(message):
         secrets.append(message)
+
         class R:
             def execute(self):
                 return "pw"
+
         return R()
 
     menu.inquirer = SimpleNamespace(secret=fake_secret)
@@ -30,4 +31,4 @@ def test_db_list_auth_flow(monkeypatch):
     dblist = menu._list_dbs_interactive()
     assert dblist == ["alpha", "beta"]
     assert secrets == ["Database root password:"]
-    assert env_calls == [None, "pw"]
+    assert env_calls == [None, None, None, None, "pw"]

--- a/tests/test_db_list_cache.py
+++ b/tests/test_db_list_cache.py
@@ -1,0 +1,17 @@
+from lampkitctl import db_introspect
+
+
+def test_cache_root_password(monkeypatch):
+    db_introspect._CACHED_ROOT_PASSWORD = None
+    db_introspect.cache_root_password("secret")
+    seen = []
+
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
+        seen.append(env.get("MYSQL_PWD"))
+        return "db1\n"
+
+    monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
+
+    dblist = db_introspect.list_databases()
+    assert dblist.databases == ["db1"]
+    assert seen == ["secret"]

--- a/tests/test_db_list_fallbacks.py
+++ b/tests/test_db_list_fallbacks.py
@@ -1,0 +1,39 @@
+import subprocess
+from lampkitctl import db_introspect
+
+
+def test_defaults_file_fallback(monkeypatch):
+    calls = []
+
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
+        calls.append(cmd)
+        if len(calls) < 4:
+            raise subprocess.CalledProcessError(1, cmd, output="fail")
+        return "alpha\nbeta\n"
+
+    monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
+
+    dblist = db_introspect.list_databases()
+    assert dblist.databases == ["alpha", "beta"]
+    assert calls[0][0] == "mysql"
+    assert calls[1][0] == "mysql"
+    assert calls[2][0] == "sudo"
+    assert "--defaults-file=/etc/mysql/debian.cnf" in calls[3]
+
+
+def test_tcp_success_after_password(monkeypatch):
+    calls = []
+
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
+        calls.append(cmd)
+        if "--protocol=socket" in cmd:
+            raise subprocess.CalledProcessError(1, cmd, output="socket fail")
+        assert env.get("MYSQL_PWD") == "pw"
+        assert "-h" in cmd and "127.0.0.1" in cmd
+        return "mydb\n"
+
+    monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
+
+    dblist = db_introspect.list_databases(password="pw")
+    assert dblist.databases == ["mydb"]
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- retry DB listing over socket, TCP, and sudo-based defaults-file strategies
- prompt once for root password then fall back to sudo if needed
- document multi-strategy picker and add tests for fallback chain and password caching

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4aeaaf8048322af5fdb467056968b