### PR TITLE
feat(tui/db): sudo-aware DB listing with wp-config prefill & secure prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ In the menu, **Set WordPress permissions**, **Uninstall site**, and **Generate S
 
 When uninstalling a site, the menu now presents a **database picker** listing local MySQL/MariaDB databases. If the selected site is a WordPress install and `wp-config.php` declares a database that exists on the server, that database is **pre-selected**.
 
-**Database picker**: The menu automatically tries multiple strategies to list databases: socket, TCP to `127.0.0.1`, and sudo fallbacks (including Debian maintenance credentials). If all fail, it falls back to manual database entry. To avoid interactive prompts, set an environment variable before launching the menu:
+**Database picker**: The menu first tries the local socket and TCP (`127.0.0.1:3306`), using `MYSQL_PWD` if provided. If that fails (e.g., `root` authenticates via `unix_socket`), it can prompt for the **DB root password** and retry, then for the **sudo password** to enumerate as root or via `/etc/mysql/debian.cnf`. If all attempts fail, the menu falls back to manual entry and will prefill the name found in `wp-config.php` when available. To avoid interactive prompts, set an environment variable before launching the menu:
 
 ```bash
 export LAMPKITCTL_DB_ROOT_PASS='your-root-password'

--- a/lampkitctl/db_introspect.py
+++ b/lampkitctl/db_introspect.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
+
+import os
+import re
+import subprocess
 from dataclasses import dataclass
 from typing import Optional
-import os, re, subprocess, shlex
 
 SYSTEM_SCHEMAS = {"information_schema", "mysql", "performance_schema", "sys"}
 
-# Cached password for the session (process lifetime only)
 _CACHED_ROOT_PASSWORD: Optional[str] = None
 
 
-@dataclass
-class DBList:
-    databases: list[str]
+class DBListError(RuntimeError):
+    """Raised when database listing fails."""
 
 
 def _env_with_pwd(pwd: Optional[str]) -> dict:
@@ -22,90 +23,100 @@ def _env_with_pwd(pwd: Optional[str]) -> dict:
     return env
 
 
-class DBListError(RuntimeError):
-    pass
+_DEF_CMD_SOCKET = [
+    "mysql",
+    "--protocol=socket",
+    "-u",
+    "root",
+    "-N",
+    "-B",
+    "-e",
+    "SHOW DATABASES",
+]
+_DEF_CMD_TCP = [
+    "mysql",
+    "-h",
+    "127.0.0.1",
+    "-P",
+    "3306",
+    "-u",
+    "root",
+    "-N",
+    "-B",
+    "-e",
+    "SHOW DATABASES",
+]
+
+_SUDO_CMD_SOCKET = [
+    "sudo",
+    "-S",
+    "mysql",
+    "--protocol=socket",
+    "-u",
+    "root",
+    "-N",
+    "-B",
+    "-e",
+    "SHOW DATABASES",
+]
+_SUDO_CMD_DCNF = [
+    "sudo",
+    "-S",
+    "mysql",
+    "--defaults-file=/etc/mysql/debian.cnf",
+    "-N",
+    "-B",
+    "-e",
+    "SHOW DATABASES",
+]
 
 
-_ATTEMPTS = (
-    ["mysql", "--protocol=socket", "-u", "root", "-N", "-B", "-e", "SHOW DATABASES"],
-    [
-        "mysql",
-        "-h",
-        "127.0.0.1",
-        "-P",
-        "3306",
-        "-u",
-        "root",
-        "-N",
-        "-B",
-        "-e",
-        "SHOW DATABASES",
-    ],
-)
-
-
-_SUDO_ATTEMPTS = (
-    [
-        "sudo",
-        "-n",
-        "mysql",
-        "--protocol=socket",
-        "-u",
-        "root",
-        "-N",
-        "-B",
-        "-e",
-        "SHOW DATABASES",
-    ],
-    [
-        "sudo",
-        "-n",
-        "mysql",
-        "--defaults-file=/etc/mysql/debian.cnf",
-        "-N",
-        "-B",
-        "-e",
-        "SHOW DATABASES",
-    ],
-)
-
-
-def list_databases(password: Optional[str] = None) -> DBList:
-    env = _env_with_pwd(password)
-    last_err: Optional[Exception] = None
-
-    for cmd in _ATTEMPTS:
-        try:
-            out = subprocess.check_output(cmd, env=env, text=True, stderr=subprocess.STDOUT)
-            names = [ln.strip() for ln in out.splitlines() if ln.strip()]
-            names = [n for n in names if n not in SYSTEM_SCHEMAS]
-            names.sort()
-            return DBList(names)
-        except Exception as exc:  # pragma: no cover - error path
-            last_err = exc
-
-    for cmd in _SUDO_ATTEMPTS:
-        try:
-            out = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
-            names = [ln.strip() for ln in out.splitlines() if ln.strip()]
-            names = [n for n in names if n not in SYSTEM_SCHEMAS]
-            names.sort()
-            return DBList(names)
-        except Exception as exc:  # pragma: no cover - error path
-            last_err = exc
-
-    raise DBListError(str(last_err) if last_err else "Unknown DB list error")
+def _parse_names(output: str) -> list[str]:
+    names = [ln.strip() for ln in output.splitlines() if ln.strip()]
+    return sorted(n for n in names if n not in SYSTEM_SCHEMAS)
 
 
 def cache_root_password(pwd: str) -> None:
     global _CACHED_ROOT_PASSWORD
     _CACHED_ROOT_PASSWORD = pwd
 
+
+def list_databases(password: Optional[str] = None) -> list[str]:
+    env = _env_with_pwd(password)
+    last_err: Optional[Exception] = None
+
+    for cmd in (_DEF_CMD_SOCKET, _DEF_CMD_TCP):
+        try:
+            out = subprocess.check_output(cmd, env=env, text=True, stderr=subprocess.STDOUT)
+            return _parse_names(out)
+        except Exception as exc:  # pragma: no cover - error path
+            last_err = exc
+
+    raise DBListError(str(last_err) if last_err else "DB list failed")
+
+
+def list_databases_with_sudo(sudo_password: str) -> list[str]:
+    last_err: Optional[Exception] = None
+    for cmd in (_SUDO_CMD_SOCKET, _SUDO_CMD_DCNF):
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=f"{sudo_password}\n",
+                text=True,
+                check=True,
+                capture_output=True,
+            )
+            return _parse_names(proc.stdout)
+        except Exception as exc:  # pragma: no cover - error path
+            last_err = exc
+    raise DBListError(str(last_err) if last_err else "DB sudo list failed")
+
+
 WP_DB_NAME_RE = re.compile(r"define\(\s*['\"]DB_NAME['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
 WP_DB_USER_RE = re.compile(r"define\(\s*['\"]DB_USER['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
 WP_DB_HOST_RE = re.compile(r"define\(\s*['\"]DB_HOST['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
-# Optional: table prefix
 WP_TABLE_PREFIX_RE = re.compile(r"^\s*\$table_prefix\s*=\s*['\"]([^'\"]+)['\"];", re.MULTILINE)
+
 
 @dataclass
 class WPConfig:
@@ -113,6 +124,7 @@ class WPConfig:
     user: str | None
     host: str | None
     table_prefix: str | None
+
 
 def parse_wp_config(docroot: str) -> WPConfig | None:
     path = os.path.join(docroot, "wp-config.php")
@@ -128,3 +140,4 @@ def parse_wp_config(docroot: str) -> WPConfig | None:
     pref_m = WP_TABLE_PREFIX_RE.search(data)
     prefix = pref_m.group(1) if pref_m else None
     return WPConfig(name, user, host, prefix)
+

--- a/tests/test_db_list_cache.py
+++ b/tests/test_db_list_cache.py
@@ -13,5 +13,5 @@ def test_cache_root_password(monkeypatch):
     monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
 
     dblist = db_introspect.list_databases()
-    assert dblist.databases == ["db1"]
+    assert dblist == ["db1"]
     assert seen == ["secret"]

--- a/tests/test_db_list_env_var.py
+++ b/tests/test_db_list_env_var.py
@@ -1,5 +1,5 @@
-from types import SimpleNamespace
-from lampkitctl import menu, db_introspect
+from lampkitctl import db_introspect
+
 
 def test_db_list_env_var(monkeypatch):
     db_introspect._CACHED_ROOT_PASSWORD = None
@@ -12,11 +12,6 @@ def test_db_list_env_var(monkeypatch):
 
     monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
 
-    def fake_secret(message):
-        raise AssertionError("prompt should not be called")
-
-    menu.inquirer = SimpleNamespace(secret=fake_secret)
-
-    dblist = menu._list_dbs_interactive()
+    dblist = db_introspect.list_databases()
     assert dblist == ["mydb"]
     assert env_calls == ["pw"]

--- a/tests/test_db_list_fallbacks.py
+++ b/tests/test_db_list_fallbacks.py
@@ -2,25 +2,6 @@ import subprocess
 from lampkitctl import db_introspect
 
 
-def test_defaults_file_fallback(monkeypatch):
-    calls = []
-
-    def fake_check_output(cmd, env=None, text=None, stderr=None):
-        calls.append(cmd)
-        if len(calls) < 4:
-            raise subprocess.CalledProcessError(1, cmd, output="fail")
-        return "alpha\nbeta\n"
-
-    monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
-
-    dblist = db_introspect.list_databases()
-    assert dblist.databases == ["alpha", "beta"]
-    assert calls[0][0] == "mysql"
-    assert calls[1][0] == "mysql"
-    assert calls[2][0] == "sudo"
-    assert "--defaults-file=/etc/mysql/debian.cnf" in calls[3]
-
-
 def test_tcp_success_after_password(monkeypatch):
     calls = []
 
@@ -35,5 +16,5 @@ def test_tcp_success_after_password(monkeypatch):
     monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
 
     dblist = db_introspect.list_databases(password="pw")
-    assert dblist.databases == ["mydb"]
+    assert dblist == ["mydb"]
     assert len(calls) == 2

--- a/tests/test_db_list_filters_system.py
+++ b/tests/test_db_list_filters_system.py
@@ -7,4 +7,4 @@ def test_filters_system(monkeypatch):
 
     monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
     dblist = db_introspect.list_databases()
-    assert dblist.databases == ["custom1", "mydb"]
+    assert dblist == ["custom1", "mydb"]

--- a/tests/test_db_list_sudo_fallbacks.py
+++ b/tests/test_db_list_sudo_fallbacks.py
@@ -1,0 +1,20 @@
+import subprocess
+from lampkitctl import db_introspect
+
+
+def test_sudo_defaults_file_fallback(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, input=None, text=None, check=None, capture_output=None):
+        calls.append(cmd)
+        if "--protocol=socket" in cmd:
+            raise subprocess.CalledProcessError(1, cmd, "fail")
+        assert "--defaults-file=/etc/mysql/debian.cnf" in cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="alpha\nbeta\n", stderr="")
+
+    monkeypatch.setattr(db_introspect.subprocess, "run", fake_run)
+
+    dblist = db_introspect.list_databases_with_sudo("pw")
+    assert dblist == ["alpha", "beta"]
+    assert len(calls) == 2
+

--- a/tests/test_menu_db_picker_prefill.py
+++ b/tests/test_menu_db_picker_prefill.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+from lampkitctl import menu, db_introspect
+
+
+def test_db_picker_prefills_from_wp_config(monkeypatch):
+    monkeypatch.setattr(menu.dbi, "list_databases", lambda password=None: (_ for _ in ()).throw(Exception("fail")))
+    monkeypatch.setattr(menu.dbi, "list_databases_with_sudo", lambda pw: (_ for _ in ()).throw(Exception("fail")))
+    monkeypatch.setattr(
+        menu.db_introspect,
+        "parse_wp_config",
+        lambda path: db_introspect.WPConfig("wpdb", None, None, None),
+    )
+    warns = []
+    monkeypatch.setattr(menu, "_warn", lambda msg: warns.append(msg))
+
+    def fake_secret(message):
+        class R:
+            def execute(self):
+                return ""
+
+        return R()
+
+    menu.inquirer = SimpleNamespace(secret=fake_secret, text=lambda **k: None)
+
+    result = menu._db_picker_with_fallbacks("/a")
+    assert result == "wpdb"
+    assert warns == ["Could not list databases. Using DB from wp-config.php: wpdb"]
+

--- a/tests/test_menu_db_picker_preselect.py
+++ b/tests/test_menu_db_picker_preselect.py
@@ -9,11 +9,7 @@ def make_vhost(domain, docroot):
 def test_db_picker_preselects_wp_db(monkeypatch):
     vhost = make_vhost("a.com", "/a")
     monkeypatch.setattr(menu, "_choose_site", lambda: vhost)
-    monkeypatch.setattr(
-        menu.db_introspect,
-        "list_databases",
-        lambda: db_introspect.DBList(["wpdb", "other"]),
-    )
+    monkeypatch.setattr(menu.dbi, "list_databases", lambda password=None: ["wpdb", "other"])
     monkeypatch.setattr(
         menu.db_introspect,
         "parse_wp_config",
@@ -22,12 +18,14 @@ def test_db_picker_preselects_wp_db(monkeypatch):
 
     def fake_select(message=None, choices=None, default=None):
         fake_select.default = default
+
         class R:
             def execute(self):
                 return default
+
         return R()
 
-    menu.inquirer = SimpleNamespace(select=fake_select, text=lambda **k: None)
+    menu.inquirer = SimpleNamespace(select=fake_select, text=lambda **k: None, secret=lambda **k: None)
     monkeypatch.setattr(menu, "_text", lambda *a, **k: "dbuser")
     monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
     calls = []
@@ -44,46 +42,3 @@ def test_db_picker_preselects_wp_db(monkeypatch):
         "dbuser",
     ]]
     assert fake_select.default == "wpdb"
-
-
-def test_db_picker_warns_missing_wp_db(monkeypatch):
-    vhost = make_vhost("a.com", "/a")
-    monkeypatch.setattr(menu, "_choose_site", lambda: vhost)
-    monkeypatch.setattr(
-        menu.db_introspect,
-        "list_databases",
-        lambda: db_introspect.DBList(["alpha", "beta"]),
-    )
-    monkeypatch.setattr(
-        menu.db_introspect,
-        "parse_wp_config",
-        lambda path: db_introspect.WPConfig("missing", None, None, None),
-    )
-    warns = []
-    monkeypatch.setattr(menu, "echo_warn", lambda msg: warns.append(msg))
-
-    def fake_select(message=None, choices=None, default=None):
-        fake_select.default = default
-        class R:
-            def execute(self):
-                return default
-        return R()
-
-    menu.inquirer = SimpleNamespace(select=fake_select, text=lambda **k: None)
-    monkeypatch.setattr(menu, "_text", lambda *a, **k: "dbuser")
-    monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
-    calls = []
-    monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: calls.append(args) or 0)
-    menu._uninstall_site_flow(dry_run=False)
-    assert calls == [[
-        "uninstall-site",
-        "a.com",
-        "--doc-root",
-        "/a",
-        "--db-name",
-        "alpha",
-        "--db-user",
-        "dbuser",
-    ]]
-    assert fake_select.default == "alpha"
-    assert warns == ["DB from wp-config.php not found on server: missing"]

--- a/tests/test_menu_site_selection.py
+++ b/tests/test_menu_site_selection.py
@@ -28,7 +28,7 @@ def test_uninstall_site_uses_selected_domain(monkeypatch):
     monkeypatch.setattr(menu, "inquirer", None)
     inputs = iter(["1"])  # select first site
     monkeypatch.setattr(menu, "input", lambda _: next(inputs), raising=False)
-    monkeypatch.setattr(menu, "_choose_database", lambda doc_root: "dbname")
+    monkeypatch.setattr(menu, "_db_picker_with_fallbacks", lambda doc_root: "dbname")
     texts = iter(["dbuser"])
     monkeypatch.setattr(menu, "_text", lambda *a, **k: next(texts))
     monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)


### PR DESCRIPTION
## Summary
- add sudo-aware database discovery with in-memory credential handling
- prefill database choice from wp-config and improve manual fallback UX
- document database picker escalation flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b1f1e0c4832285189648100cd8ab