### PR TITLE
feat(tui/db): user picker with WordPress preselect and sudo fallbacks (user@host)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ In the menu, **Set WordPress permissions**, **Uninstall site**, and **Generate S
 
 When uninstalling a site, the menu now presents a **database picker** listing local MySQL/MariaDB databases. If the selected site is a WordPress install and `wp-config.php` declares a database that exists on the server, that database is **pre-selected**.
 
+During **Uninstall site**, a picker also lists database **users** (`user@host`). For WordPress sites, the user from `wp-config.php` is pre-selected. If enumeration requires credentials, the menu securely prompts for the database root and/or sudo password. Should listing fail entirely, the flow falls back to manual entry and pre-fills the user from `wp-config.php` when available.
+
 **Database picker**: The menu first tries the local socket and TCP (`127.0.0.1:3306`), using `MYSQL_PWD` if provided. If that fails (e.g., `root` authenticates via `unix_socket`), it can prompt for the **DB root password** and retry, then for the **sudo password** to enumerate as root or via `/etc/mysql/debian.cnf`. If all attempts fail, the menu falls back to manual entry and will prefill the name found in `wp-config.php` when available. To avoid interactive prompts, set an environment variable before launching the menu:
 
 ```bash

--- a/lampkitctl/db_introspect.py
+++ b/lampkitctl/db_introspect.py
@@ -112,6 +112,115 @@ def list_databases_with_sudo(sudo_password: str) -> list[str]:
     raise DBListError(str(last_err) if last_err else "DB sudo list failed")
 
 
+# ---------------------------------------------------------------------------
+# User listing
+# ---------------------------------------------------------------------------
+
+SYSTEM_USERS = {"mysql.sys", "mysql.session", "debian-sys-maint"}
+HIDE_USERS = SYSTEM_USERS | {"root"}
+
+
+@dataclass
+class DBUsers:
+    items: list[str]  # values like "user@host"
+
+
+_DEF_SQL_USERS = (
+    "SELECT CONCAT(User, '@', Host) FROM mysql.user ORDER BY User, Host;",
+)
+
+_DEF_CMD_SOCKET_USERS = [
+    "mysql",
+    "--protocol=socket",
+    "-u",
+    "root",
+    "-N",
+    "-B",
+    "-e",
+    _DEF_SQL_USERS[0],
+]
+_DEF_CMD_TCP_USERS = [
+    "mysql",
+    "-h",
+    "127.0.0.1",
+    "-P",
+    "3306",
+    "-u",
+    "root",
+    "-N",
+    "-B",
+    "-e",
+    _DEF_SQL_USERS[0],
+]
+
+_SUDO_CMD_SOCKET_USERS = [
+    "sudo",
+    "-S",
+    "mysql",
+    "--protocol=socket",
+    "-u",
+    "root",
+    "-N",
+    "-B",
+    "-e",
+    _DEF_SQL_USERS[0],
+]
+_SUDO_CMD_DCNF_USERS = [
+    "sudo",
+    "-S",
+    "mysql",
+    "--defaults-file=/etc/mysql/debian.cnf",
+    "-N",
+    "-B",
+    "-e",
+    _DEF_SQL_USERS[0],
+]
+
+
+class DBUserListError(RuntimeError):
+    pass
+
+
+_DEF_PARSE = lambda out: sorted(
+    u
+    for u in (ln.strip() for ln in out.splitlines() if ln.strip())
+    if u.split("@", 1)[0] not in HIDE_USERS
+)
+
+
+def list_users(password: Optional[str] = None) -> DBUsers:
+    env = _env_with_pwd(password)
+    last_err: Optional[Exception] = None
+    for cmd in (_DEF_CMD_SOCKET_USERS, _DEF_CMD_TCP_USERS):
+        try:
+            out = subprocess.check_output(
+                cmd, env=env, text=True, stderr=subprocess.STDOUT
+            )
+            return DBUsers(_DEF_PARSE(out))
+        except Exception as exc:  # pragma: no cover - error path
+            last_err = exc
+    raise DBUserListError(str(last_err) if last_err else "DB user list failed")
+
+
+def list_users_with_sudo(sudo_password: str) -> DBUsers:
+    last_err: Optional[Exception] = None
+    for cmd in (_SUDO_CMD_SOCKET_USERS, _SUDO_CMD_DCNF_USERS):
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=f"{sudo_password}\n",
+                text=True,
+                check=True,
+                capture_output=True,
+            )
+            return DBUsers(_DEF_PARSE(proc.stdout))
+        except Exception as exc:  # pragma: no cover - error path
+            last_err = exc
+    raise DBUserListError(
+        str(last_err) if last_err else "DB user sudo list failed"
+    )
+
+
 WP_DB_NAME_RE = re.compile(r"define\(\s*['\"]DB_NAME['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
 WP_DB_USER_RE = re.compile(r"define\(\s*['\"]DB_USER['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")
 WP_DB_HOST_RE = re.compile(r"define\(\s*['\"]DB_HOST['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)")

--- a/lampkitctl/db_ops.py
+++ b/lampkitctl/db_ops.py
@@ -129,12 +129,13 @@ def drop_database_and_user(
 ) -> None:
     """Remove a MySQL database and its user.
 
-    The database is dropped if it exists and the associated user is removed
-    along with its privileges.
+    ``user`` may include an optional host (``user@host``). When no host is
+    provided, ``localhost`` is assumed. The database is dropped if it exists
+    and the associated user is removed along with its privileges.
 
     Args:
         db_name (str): Name of the database to drop.
-        user (str): Username to remove.
+        user (str): Username to remove, optionally with host.
         root_user (str, optional): MySQL root username used to execute the
             SQL commands. Defaults to "root".
         root_password (Optional[str], optional): Password for ``root_user``.
@@ -152,9 +153,13 @@ def drop_database_and_user(
     Example:
         >>> drop_database_and_user("blog", "blog_user", dry_run=True)
     """
+    if "@" in user:
+        user_name, host = user.split("@", 1)
+    else:
+        user_name, host = user, "localhost"
     sql = (
         f"DROP DATABASE IF EXISTS `{db_name}`;"
-        f" DROP USER IF EXISTS '{user}'@'localhost';"
+        f" DROP USER IF EXISTS '{user_name}'@'{host}';"
         " FLUSH PRIVILEGES;"
     )
     cmd = ["mysql", "-u", root_user]

--- a/tests/test_db_user_list_fallbacks.py
+++ b/tests/test_db_user_list_fallbacks.py
@@ -1,0 +1,22 @@
+import subprocess
+from lampkitctl import db_introspect
+
+
+def test_user_sudo_defaults_file_fallback(monkeypatch) -> None:
+    calls = []
+
+    def fake_run(cmd, input=None, text=None, check=None, capture_output=None):
+        calls.append(cmd)
+        if "--protocol=socket" in cmd:
+            raise subprocess.CalledProcessError(1, cmd, "fail")
+        assert "--defaults-file=/etc/mysql/debian.cnf" in cmd
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="beta@localhost\nalpha@localhost\n", stderr=""
+        )
+
+    monkeypatch.setattr(db_introspect.subprocess, "run", fake_run)
+
+    users = db_introspect.list_users_with_sudo("pw")
+    assert users.items == ["alpha@localhost", "beta@localhost"]
+    assert len(calls) == 2
+

--- a/tests/test_db_user_list_filters.py
+++ b/tests/test_db_user_list_filters.py
@@ -1,0 +1,17 @@
+from lampkitctl import db_introspect
+
+
+def test_user_list_filters_and_sorts(monkeypatch) -> None:
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
+        return (
+            "bob@localhost\n"
+            "mysql.sys@localhost\n"
+            "debian-sys-maint@localhost\n"
+            "alice@localhost\n"
+            "root@localhost\n"
+        )
+
+    monkeypatch.setattr(db_introspect.subprocess, "check_output", fake_check_output)
+    users = db_introspect.list_users().items
+    assert users == ["alice@localhost", "bob@localhost"]
+

--- a/tests/test_menu_db_picker_preselect.py
+++ b/tests/test_menu_db_picker_preselect.py
@@ -25,8 +25,10 @@ def test_db_picker_preselects_wp_db(monkeypatch):
 
         return R()
 
-    menu.inquirer = SimpleNamespace(select=fake_select, text=lambda **k: None, secret=lambda **k: None)
-    monkeypatch.setattr(menu, "_text", lambda *a, **k: "dbuser")
+    menu.inquirer = SimpleNamespace(
+        select=fake_select, text=lambda **k: None, secret=lambda **k: None
+    )
+    monkeypatch.setattr(menu, "_db_user_picker_with_fallbacks", lambda doc_root: "dbuser")
     monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
     calls = []
     monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: calls.append(args) or 0)

--- a/tests/test_menu_db_user_picker_prefill.py
+++ b/tests/test_menu_db_user_picker_prefill.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from lampkitctl import menu, db_introspect
+
+
+def test_db_user_picker_prefills_from_wp_config(monkeypatch) -> None:
+    monkeypatch.setattr(
+        menu.dbi,
+        "list_users",
+        lambda password=None: (_ for _ in ()).throw(Exception("fail")),
+    )
+    monkeypatch.setattr(
+        menu.dbi,
+        "list_users_with_sudo",
+        lambda pw: (_ for _ in ()).throw(Exception("fail")),
+    )
+    monkeypatch.setattr(
+        menu.db_introspect,
+        "parse_wp_config",
+        lambda path: db_introspect.WPConfig(None, "wpuser", "dbhost", None),
+    )
+
+    warns: list[str] = []
+    monkeypatch.setattr(menu, "_warn", lambda msg: warns.append(msg))
+
+    def fake_secret(message):
+        class R:
+            def execute(self):
+                return ""
+
+        return R()
+
+    menu.inquirer = SimpleNamespace(secret=fake_secret, text=lambda **k: None)
+
+    result = menu._db_user_picker_with_fallbacks("/a")
+    assert result == "wpuser@dbhost"
+    assert warns == [
+        "Could not list DB users. Using wp-config.php user: wpuser@dbhost"
+    ]
+

--- a/tests/test_menu_site_selection.py
+++ b/tests/test_menu_site_selection.py
@@ -29,8 +29,9 @@ def test_uninstall_site_uses_selected_domain(monkeypatch):
     inputs = iter(["1"])  # select first site
     monkeypatch.setattr(menu, "input", lambda _: next(inputs), raising=False)
     monkeypatch.setattr(menu, "_db_picker_with_fallbacks", lambda doc_root: "dbname")
-    texts = iter(["dbuser"])
-    monkeypatch.setattr(menu, "_text", lambda *a, **k: next(texts))
+    monkeypatch.setattr(
+        menu, "_db_user_picker_with_fallbacks", lambda doc_root: "dbuser"
+    )
     monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
     calls = []
     monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: calls.append(args) or 0)

--- a/tests/test_uninstall_user_host_parse.py
+++ b/tests/test_uninstall_user_host_parse.py
@@ -1,0 +1,17 @@
+from lampkitctl import db_ops
+
+
+def test_drop_database_and_user_host_parse(monkeypatch) -> None:
+    sqls: list[str] = []
+
+    def fake_run(cmd, dry_run, log_cmd=None):
+        sqls.append(cmd[-1])
+
+    monkeypatch.setattr(db_ops, "run_command", fake_run)
+
+    db_ops.drop_database_and_user("mydb", "alice@host", dry_run=True)
+    assert "DROP USER IF EXISTS 'alice'@'host';" in sqls[-1]
+
+    db_ops.drop_database_and_user("mydb", "bob", dry_run=True)
+    assert "DROP USER IF EXISTS 'bob'@'localhost';" in sqls[-1]
+


### PR DESCRIPTION
## Summary
- add MySQL/MariaDB user enumeration with password/sudo fallbacks and system-user filtering
- expose interactive DB user picker prefilled from wp-config.php and integrate with uninstall flow
- support user@host parsing when dropping DB users

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b5531af48322ae2f3a818ea1522b