### PR TITLE
feat(tui/auth): one-time DB/sudo prompts + empty state for List sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ It targets both advanced users—through granular commands—and less experience
   Issues and configures certificates for configured domains.
 
 * ✅ **List & remove sites**
-  Lists configured sites; controlled uninstall (with confirmations and optional DB removal).
+  Lists configured sites; controlled uninstall (with confirmations and optional DB removal). Shows `No sites found` when no vhosts are present.
 
 * ✅ **Dry-run mode**
   Simulates actions **without changing** the system.
 
 * ✅ **Structured logging**
   Clear runtime messages and optional JSON logging for CI/log pipelines.
+* ✅ **One-time credential prompts**
+  Database root and sudo passwords are requested at most once per TUI session and reused silently.
 
 > **Note:** An **interactive menu (TUI)** will be available as an optional entrypoint (see [Roadmap](#roadmap)).
 

--- a/lampkitctl/auth_cache.py
+++ b/lampkitctl/auth_cache.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class _Auth:
+    db_root_password: Optional[str] = None
+    sudo_password: Optional[str] = None
+
+_AUTH = _Auth()
+
+def get_db_root_password() -> Optional[str]:
+    return _AUTH.db_root_password
+
+def set_db_root_password(p: str | None) -> None:
+    _AUTH.db_root_password = p
+
+def get_sudo_password() -> Optional[str]:
+    return _AUTH.sudo_password
+
+def set_sudo_password(p: str | None) -> None:
+    _AUTH.sudo_password = p
+
+def clear() -> None:  # for tests
+    _AUTH.db_root_password = None
+    _AUTH.sudo_password = None

--- a/lampkitctl/cli.py
+++ b/lampkitctl/cli.py
@@ -246,7 +246,7 @@ def create_site(
     auth_mode = db_root_auth
     if auth_mode == "auto":
         auth_mode = "socket" if db_ops.detect_engine() == "mariadb" else "password"
-    root_pw = db_root_pass
+    root_pw = db_root_pass or os.environ.get("LAMPKITCTL_DB_ROOT_PASS")
     if auth_mode == "password" and not root_pw:
         if dry_run:
             root_pw = ""
@@ -314,7 +314,7 @@ def uninstall_site(
     auth_mode = db_root_auth
     if auth_mode == "auto":
         auth_mode = "socket" if db_ops.detect_engine() == "mariadb" else "password"
-    root_pw = db_root_pass
+    root_pw = db_root_pass or os.environ.get("LAMPKITCTL_DB_ROOT_PASS")
     if auth_mode == "password" and not root_pw:
         if dry_run:
             root_pw = ""
@@ -344,7 +344,11 @@ def list_sites() -> None:
     if not preflight.has_cmd("apache2").ok or not preflight.apache_paths_present().ok:
         click.echo("Apache not installed. No sites to list.")
         return
-    for site in system_ops.list_sites():
+    sites = system_ops.list_sites()
+    if not sites:
+        click.echo("No sites found")
+        return
+    for site in sites:
         click.echo(f"{site['domain']} -> {site['doc_root']}")
 
 

--- a/lampkitctl/db_introspect.py
+++ b/lampkitctl/db_introspect.py
@@ -6,9 +6,9 @@ import subprocess
 from dataclasses import dataclass
 from typing import Optional
 
-SYSTEM_SCHEMAS = {"information_schema", "mysql", "performance_schema", "sys"}
+from . import auth_cache
 
-_CACHED_ROOT_PASSWORD: Optional[str] = None
+SYSTEM_SCHEMAS = {"information_schema", "mysql", "performance_schema", "sys"}
 
 
 class DBListError(RuntimeError):
@@ -17,7 +17,7 @@ class DBListError(RuntimeError):
 
 def _env_with_pwd(pwd: Optional[str]) -> dict:
     env = os.environ.copy()
-    p = pwd or env.get("LAMPKITCTL_DB_ROOT_PASS") or _CACHED_ROOT_PASSWORD
+    p = pwd or env.get("LAMPKITCTL_DB_ROOT_PASS") or auth_cache.get_db_root_password()
     if p:
         env["MYSQL_PWD"] = p
     return env
@@ -77,8 +77,8 @@ def _parse_names(output: str) -> list[str]:
 
 
 def cache_root_password(pwd: str) -> None:
-    global _CACHED_ROOT_PASSWORD
-    _CACHED_ROOT_PASSWORD = pwd
+    """Backward-compatible setter for DB root password cache."""
+    auth_cache.set_db_root_password(pwd)
 
 
 def list_databases(password: Optional[str] = None) -> list[str]:

--- a/lampkitctl/db_ops.py
+++ b/lampkitctl/db_ops.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from .utils import run_command
 import textwrap
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -109,14 +110,13 @@ def create_database_and_user(
         f" GRANT ALL PRIVILEGES ON `{db_name}`.* TO '{user}'@'localhost';"
         " FLUSH PRIVILEGES;"
     )
-    cmd = ["mysql", "-u", root_user]
-    log_cmd = ["mysql", "-u", root_user]
+    cmd = ["mysql", "-u", root_user, "-e", sql]
+    log_cmd = ["mysql", "-u", root_user, "-e", "<SQL>"]
+    env = None
     if root_password:
-        cmd.append(f"-p{root_password}")
-        log_cmd.append("-p******")
-    cmd.extend(["-e", sql])
-    log_cmd.extend(["-e", "<SQL>"])
-    run_command(cmd, dry_run, log_cmd=log_cmd)
+        env = os.environ.copy()
+        env["MYSQL_PWD"] = root_password
+    run_command(cmd, dry_run, log_cmd=log_cmd, env=env)
 
 
 def drop_database_and_user(
@@ -162,11 +162,10 @@ def drop_database_and_user(
         f" DROP USER IF EXISTS '{user_name}'@'{host}';"
         " FLUSH PRIVILEGES;"
     )
-    cmd = ["mysql", "-u", root_user]
-    log_cmd = ["mysql", "-u", root_user]
+    cmd = ["mysql", "-u", root_user, "-e", sql]
+    log_cmd = ["mysql", "-u", root_user, "-e", "<SQL>"]
+    env = None
     if root_password:
-        cmd.append(f"-p{root_password}")
-        log_cmd.append("-p******")
-    cmd.extend(["-e", sql])
-    log_cmd.extend(["-e", "<SQL>"])
-    run_command(cmd, dry_run, log_cmd=log_cmd)
+        env = os.environ.copy()
+        env["MYSQL_PWD"] = root_password
+    run_command(cmd, dry_run, log_cmd=log_cmd, env=env)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,3 +2,11 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from lampkitctl import auth_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_cache():
+    auth_cache.clear()

--- a/tests/test_auth_cache.py
+++ b/tests/test_auth_cache.py
@@ -1,0 +1,14 @@
+from lampkitctl import auth_cache
+
+
+def test_auth_cache_roundtrip():
+    auth_cache.clear()
+    assert auth_cache.get_db_root_password() is None
+    assert auth_cache.get_sudo_password() is None
+    auth_cache.set_db_root_password("db")
+    auth_cache.set_sudo_password("su")
+    assert auth_cache.get_db_root_password() == "db"
+    assert auth_cache.get_sudo_password() == "su"
+    auth_cache.clear()
+    assert auth_cache.get_db_root_password() is None
+    assert auth_cache.get_sudo_password() is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,36 @@ def test_cli_uninstall_site(monkeypatch) -> None:
     assert result.exit_code == 0
 
 
+def test_cli_uninstall_site_env_pass(monkeypatch) -> None:
+    monkeypatch.setattr(cli.preflight, "ensure_or_fail", lambda *a, **k: None)
+    monkeypatch.setattr(cli.utils, "prompt_confirm", lambda *a, **k: True)
+    monkeypatch.setattr(cli.system_ops, "remove_virtualhost", lambda *a, **k: None)
+    monkeypatch.setattr(cli.system_ops, "remove_host_entry", lambda *a, **k: None)
+    monkeypatch.setattr(cli.system_ops, "remove_web_directory", lambda *a, **k: None)
+    seen = {}
+
+    def fake_drop(db_name, db_user, *, root_password, dry_run):
+        seen["root_password"] = root_password
+
+    monkeypatch.setattr(cli.db_ops, "drop_database_and_user", fake_drop)
+    runner = CliRunner()
+    env = {"LAMPKITCTL_DB_ROOT_PASS": "pw"}
+    result = runner.invoke(
+        cli.cli,
+        [
+            "--dry-run",
+            "uninstall-site",
+            "example.com",
+            "--doc-root=/var/www/example",
+            "--db-name=db",
+            "--db-user=user",
+        ],
+        env=env,
+    )
+    assert result.exit_code == 0
+    assert seen["root_password"] == "pw"
+
+
 def test_cli_list_sites(monkeypatch) -> None:
     """Check that configured sites are listed correctly.
 
@@ -107,3 +137,18 @@ def test_cli_list_sites(monkeypatch) -> None:
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["list-sites"])
     assert "a -> /var/www/a" in result.output
+
+
+def test_cli_list_sites_empty(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cli.preflight,
+        "has_cmd",
+        lambda name, msg=None, severity=cli.preflight.Severity.BLOCKING: cli.preflight.CheckResult(True, ""),
+    )
+    monkeypatch.setattr(
+        cli.preflight, "apache_paths_present", lambda: cli.preflight.CheckResult(True, "")
+    )
+    monkeypatch.setattr(cli.system_ops, "list_sites", lambda: [])
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["list-sites"])
+    assert "No sites found" in result.output

--- a/tests/test_db_list_auth_flow.py
+++ b/tests/test_db_list_auth_flow.py
@@ -1,9 +1,10 @@
 from types import SimpleNamespace
-from lampkitctl import menu, db_introspect
+from lampkitctl import menu, db_introspect, auth_cache
 
 
 def test_db_list_auth_flow(monkeypatch):
     monkeypatch.setattr(menu.db_introspect, "parse_wp_config", lambda path: None)
+    auth_cache.clear()
 
     calls = []
 
@@ -14,7 +15,6 @@ def test_db_list_auth_flow(monkeypatch):
         raise db_introspect.DBListError("fail")
 
     monkeypatch.setattr(menu.dbi, "list_databases", fake_list)
-    monkeypatch.setattr(menu.dbi, "cache_root_password", lambda pw: None)
 
     secrets = []
 

--- a/tests/test_db_list_cache.py
+++ b/tests/test_db_list_cache.py
@@ -1,9 +1,9 @@
-from lampkitctl import db_introspect
+from lampkitctl import db_introspect, auth_cache
 
 
 def test_cache_root_password(monkeypatch):
-    db_introspect._CACHED_ROOT_PASSWORD = None
-    db_introspect.cache_root_password("secret")
+    auth_cache.clear()
+    auth_cache.set_db_root_password("secret")
     seen = []
 
     def fake_check_output(cmd, env=None, text=None, stderr=None):

--- a/tests/test_db_list_env_var.py
+++ b/tests/test_db_list_env_var.py
@@ -1,8 +1,8 @@
-from lampkitctl import db_introspect
+from lampkitctl import db_introspect, auth_cache
 
 
 def test_db_list_env_var(monkeypatch):
-    db_introspect._CACHED_ROOT_PASSWORD = None
+    auth_cache.clear()
     monkeypatch.setenv("LAMPKITCTL_DB_ROOT_PASS", "pw")
     env_calls = []
 

--- a/tests/test_db_ops.py
+++ b/tests/test_db_ops.py
@@ -9,16 +9,18 @@ def test_create_database_and_user(monkeypatch) -> None:
     """
     recorded = {}
 
-    def fake_run(cmd, dry_run, log_cmd=None):
+    def fake_run(cmd, dry_run, log_cmd=None, env=None):
         recorded["cmd"] = cmd
         recorded["log_cmd"] = list(log_cmd or [])
+        recorded["env"] = env or {}
 
     monkeypatch.setattr(db_ops, "run_command", fake_run)
     db_ops.create_database_and_user(
         "mydb", "myuser", "mypw", root_password="secret", dry_run=True
     )
-    assert any(part.startswith("-psecret") for part in recorded["cmd"])
-    assert "-p******" in recorded["log_cmd"]
+    assert "-psecret" not in recorded["cmd"]
+    assert recorded["env"]["MYSQL_PWD"] == "secret"
+    assert "-p******" not in recorded["log_cmd"]
 
 
 def test_drop_database_and_user(monkeypatch) -> None:
@@ -29,9 +31,11 @@ def test_drop_database_and_user(monkeypatch) -> None:
     """
     called = {}
 
-    def fake_run(cmd, dry_run, log_cmd=None):
+    def fake_run(cmd, dry_run, log_cmd=None, env=None):
         called["cmd"] = cmd
+        called["env"] = env or {}
 
     monkeypatch.setattr(db_ops, "run_command", fake_run)
-    db_ops.drop_database_and_user("mydb", "myuser", dry_run=True)
+    db_ops.drop_database_and_user("mydb", "myuser", root_password="pw", dry_run=True)
     assert "mysql" in called["cmd"][0]
+    assert called["env"]["MYSQL_PWD"] == "pw"

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List
+from types import SimpleNamespace
 
 import logging
 from typing import List
@@ -20,11 +21,11 @@ def test_run_menu_routing(monkeypatch):
 
     called = {}
 
-    def fake_call(args):
+    def fake_run(args, **kwargs):
         called["args"] = args
-        return 0
+        return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr(menu.subprocess, "call", fake_call)
+    monkeypatch.setattr(menu.subprocess, "run", fake_run)
 
     menu.run_menu(dry_run=True)
     assert called["args"] == [
@@ -68,3 +69,10 @@ def test_create_site_propagates_and_masks(monkeypatch, caplog):
 
     assert all(dry for _, dry in calls)
     assert "secret" not in caplog.text
+
+
+def test_list_sites_empty(monkeypatch, capsys):
+    monkeypatch.setattr(menu, "list_installed_sites", lambda: [])
+    menu._list_sites_flow()
+    out = capsys.readouterr().out
+    assert "No sites found" in out

--- a/tests/test_menu_db_choice.py
+++ b/tests/test_menu_db_choice.py
@@ -1,4 +1,5 @@
 from lampkitctl import menu
+from types import SimpleNamespace
 
 
 def test_menu_db_choice(monkeypatch):
@@ -10,11 +11,11 @@ def test_menu_db_choice(monkeypatch):
 
     called = {}
 
-    def fake_call(args):
+    def fake_run(args, **kwargs):
         called["args"] = args
-        return 0
+        return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr(menu.subprocess, "call", fake_call)
+    monkeypatch.setattr(menu.subprocess, "run", fake_run)
 
     menu.run_menu(dry_run=True)
     assert called["args"] == [

--- a/tests/test_menu_db_picker_prefill.py
+++ b/tests/test_menu_db_picker_prefill.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from lampkitctl import menu, db_introspect
+from types import SimpleNamespace
 
 
 def test_db_picker_prefills_from_wp_config(monkeypatch):

--- a/tests/test_menu_db_picker_preselect.py
+++ b/tests/test_menu_db_picker_preselect.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from lampkitctl import menu, apache_vhosts, db_introspect
+from types import SimpleNamespace
 
 
 def make_vhost(domain, docroot):

--- a/tests/test_menu_db_user_picker_prefill.py
+++ b/tests/test_menu_db_user_picker_prefill.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from lampkitctl import menu, db_introspect
+from types import SimpleNamespace
 
 
 def test_db_user_picker_prefills_from_wp_config(monkeypatch) -> None:

--- a/tests/test_menu_resume.py
+++ b/tests/test_menu_resume.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lampkitctl import menu
+from types import SimpleNamespace
 
 
 def test_menu_install_lamp_uses_sudo(monkeypatch):
@@ -9,11 +10,11 @@ def test_menu_install_lamp_uses_sudo(monkeypatch):
     monkeypatch.setattr(menu, "resolve_self_executable", lambda: "/abs/path/to/lampkitctl")
     monkeypatch.setattr(menu.os, "geteuid", lambda: 1000)
 
-    def fake_call(args):
+    def fake_run(args, **kwargs):
         captured["args"] = args
-        return 0
+        return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr(menu.subprocess, "call", fake_call)
+    monkeypatch.setattr(menu.subprocess, "run", fake_run)
 
     responses = iter(["Install LAMP server", "MySQL"])
     monkeypatch.setattr(menu, "_select", lambda message, choices: next(responses))
@@ -38,11 +39,11 @@ def test_run_cli_root_calls_subprocess(monkeypatch):
     monkeypatch.setattr(menu.os, "geteuid", lambda: 0)
     called = {}
 
-    def fake_call(args):
+    def fake_run(args, **kwargs):
         called["args"] = args
-        return 0
+        return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr(menu.subprocess, "call", fake_call)
+    monkeypatch.setattr(menu.subprocess, "run", fake_run)
 
     rc = menu._run_cli([
         "install-lamp",

--- a/tests/test_uninstall_user_host_parse.py
+++ b/tests/test_uninstall_user_host_parse.py
@@ -4,7 +4,7 @@ from lampkitctl import db_ops
 def test_drop_database_and_user_host_parse(monkeypatch) -> None:
     sqls: list[str] = []
 
-    def fake_run(cmd, dry_run, log_cmd=None):
+    def fake_run(cmd, dry_run, log_cmd=None, env=None):
         sqls.append(cmd[-1])
 
     monkeypatch.setattr(db_ops, "run_command", fake_run)


### PR DESCRIPTION
## Summary
- cache DB root and sudo passwords in-memory for reuse across TUI flows
- leverage cached credentials for DB listing, user enumeration and uninstall
- show clear message when no sites are installed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba052dc48322ba7e6715d8810179