### PR TITLE
fix(menu): don’t prompt install‑lamp after uninstall; improve List sites output (framed & colored)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It targets both advanced users—through granular commands—and less experience
   Issues and configures certificates for configured domains.
 
 * ✅ **List & remove sites**
-  Lists configured sites; controlled uninstall (with confirmations and optional DB removal). Shows `No sites found` when no vhosts are present.
+  Lists configured sites in a framed, colored output; controlled uninstall (with confirmations and optional DB removal) that never triggers LAMP installation. Shows a red `No sites found` when no vhosts are present.
 
 * ✅ **Dry-run mode**
   Simulates actions **without changing** the system.

--- a/lampkitctl/cli.py
+++ b/lampkitctl/cli.py
@@ -345,11 +345,7 @@ def list_sites() -> None:
         click.echo("Apache not installed. No sites to list.")
         return
     sites = system_ops.list_sites()
-    if not sites:
-        click.echo("No sites found")
-        return
-    for site in sites:
-        click.echo(f"{site['domain']} -> {site['doc_root']}")
+    utils.render_sites_list([(s["domain"], s["doc_root"]) for s in sites])
 
 
 @cli.command("wp-permissions")

--- a/lampkitctl/utils.py
+++ b/lampkitctl/utils.py
@@ -11,6 +11,11 @@ from typing import Iterable, List, Optional
 
 import click
 
+try:  # pragma: no cover - optional dependency
+    from InquirerPy import inquirer
+except Exception:  # pragma: no cover - gracefully handle absence
+    inquirer = None
+
 
 class JsonFormatter(logging.Formatter):
     """Format log records as JSON strings.
@@ -245,6 +250,18 @@ def prompt_yes_no(message: str, default: bool = False) -> bool:
     return prompt_confirm(message, default=default)
 
 
+def ask_confirm(msg: str, default: bool = False) -> bool:
+    """Prompt the user for confirmation returning a boolean.
+
+    This helper centralizes confirmation prompts using ``InquirerPy`` when
+    available and falling back to :func:`prompt_confirm` otherwise.
+    """
+
+    if inquirer:  # pragma: no cover - optional dependency
+        return bool(inquirer.confirm(message=msg, default=default).execute())
+    return prompt_confirm(msg, default=default)
+
+
 def echo_err(message: str) -> None:
     """Print ``message`` to standard error."""
 
@@ -276,3 +293,22 @@ def is_non_interactive() -> bool:
     """Return ``True`` if stdin is not attached to a TTY."""
 
     return not sys.stdin.isatty()
+
+
+FRAME = "#" * 33
+
+
+def render_sites_list(sites: list[tuple[str, str]]) -> None:
+    """Render a list of sites with framing and color.
+
+    Args:
+        sites: List of ``(domain, docroot)`` tuples.
+    """
+
+    if not sites:
+        click.secho("No sites found", fg="red", bold=True)
+        return
+    for domain, docroot in sites:
+        click.secho(FRAME, fg="green")
+        click.secho(f"{domain}  ->  {docroot}", fg="green", bold=True)
+        click.secho(FRAME, fg="green")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 from click.testing import CliRunner
-from lampkitctl import cli, packages, preflight, preflight_locks
+from lampkitctl import cli, packages, preflight, preflight_locks, utils
 
 
 def test_cli_install_lamp(monkeypatch) -> None:
@@ -132,11 +132,14 @@ def test_cli_list_sites(monkeypatch) -> None:
         cli.preflight, "apache_paths_present", lambda: cli.preflight.CheckResult(True, "")
     )
     monkeypatch.setattr(
-        cli.system_ops, "list_sites", lambda: [{"domain": "a", "doc_root": "/var/www/a"}]
+        cli.system_ops,
+        "list_sites",
+        lambda: [{"domain": "a.com", "doc_root": "/var/www/a"}],
     )
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["list-sites"])
-    assert "a -> /var/www/a" in result.output
+    assert utils.FRAME in result.output
+    assert "a.com  ->  /var/www/a" in result.output
 
 
 def test_cli_list_sites_empty(monkeypatch) -> None:

--- a/tests/test_menu_db_picker_preselect.py
+++ b/tests/test_menu_db_picker_preselect.py
@@ -1,6 +1,5 @@
 from types import SimpleNamespace
 from lampkitctl import menu, apache_vhosts, db_introspect
-from types import SimpleNamespace
 
 
 def make_vhost(domain, docroot):
@@ -30,7 +29,7 @@ def test_db_picker_preselects_wp_db(monkeypatch):
         select=fake_select, text=lambda **k: None, secret=lambda **k: None
     )
     monkeypatch.setattr(menu, "_db_user_picker_with_fallbacks", lambda doc_root: "dbuser")
-    monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
+    monkeypatch.setattr(menu, "ask_confirm", lambda *a, **k: True)
     calls = []
     monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: calls.append(args) or 0)
     menu._uninstall_site_flow(dry_run=False)

--- a/tests/test_menu_site_selection.py
+++ b/tests/test_menu_site_selection.py
@@ -32,7 +32,7 @@ def test_uninstall_site_uses_selected_domain(monkeypatch):
     monkeypatch.setattr(
         menu, "_db_user_picker_with_fallbacks", lambda doc_root: "dbuser"
     )
-    monkeypatch.setattr(menu, "_confirm", lambda *a, **k: True)
+    monkeypatch.setattr(menu, "ask_confirm", lambda *a, **k: True)
     calls = []
     monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: calls.append(args) or 0)
     menu._uninstall_site_flow(dry_run=False)

--- a/tests/test_render_sites_list.py
+++ b/tests/test_render_sites_list.py
@@ -1,0 +1,14 @@
+from lampkitctl import utils
+
+
+def test_list_sites_empty_state(capsys):
+    utils.render_sites_list([])
+    out = capsys.readouterr().out
+    assert "No sites found" in out
+
+
+def test_list_sites_framed_output(capsys):
+    utils.render_sites_list([("test2.com", "/var/www/test2.com")])
+    out = capsys.readouterr().out
+    assert out.count(utils.FRAME) == 2
+    assert "test2.com  ->  /var/www/test2.com" in out

--- a/tests/test_uninstall_flow.py
+++ b/tests/test_uninstall_flow.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from lampkitctl import menu, utils
+
+
+def _vhost():
+    return SimpleNamespace(domain="ex.com", docroot="/var/www/ex.com")
+
+
+def test_uninstall_never_prompts_install(monkeypatch, capsys):
+    monkeypatch.setattr(menu, "_choose_site", _vhost)
+    monkeypatch.setattr(menu, "_db_picker_with_fallbacks", lambda d: "db")
+    monkeypatch.setattr(menu, "_db_user_picker_with_fallbacks", lambda d: "user")
+    monkeypatch.setattr(menu, "ask_confirm", lambda *a, **k: True)
+
+    calls = []
+
+    def fake_run(args, dry_run=False):
+        calls.append(args)
+        return 1  # simulate failure
+
+    monkeypatch.setattr(menu, "_run_cli", fake_run)
+    menu._uninstall_site_flow(dry_run=False)
+    assert calls == [[
+        "uninstall-site",
+        "ex.com",
+        "--doc-root",
+        "/var/www/ex.com",
+        "--db-name",
+        "db",
+        "--db-user",
+        "user",
+    ]]
+    assert all("install-lamp" not in c for c in calls)
+    out = capsys.readouterr().out
+    assert "Run install-lamp now?" not in out
+
+
+def test_uninstall_confirm_boolean(monkeypatch):
+    monkeypatch.setattr(menu, "_choose_site", _vhost)
+    monkeypatch.setattr(menu, "_db_picker_with_fallbacks", lambda d: "db")
+    monkeypatch.setattr(menu, "_db_user_picker_with_fallbacks", lambda d: "user")
+
+    responses = iter([True, False])
+
+    class Dummy:
+        def execute(self):
+            return next(responses)
+
+    monkeypatch.setattr(utils, "inquirer", SimpleNamespace(confirm=lambda **k: Dummy()))
+    called = []
+    monkeypatch.setattr(menu, "_run_cli", lambda args, dry_run=False: called.append(args))
+    menu._uninstall_site_flow(dry_run=False)
+    assert not called


### PR DESCRIPTION
## Summary
- ensure uninstall flow never triggers install-lamp prompts
- add central confirm helper and framed, colored site listing
- document uninstall and list-sites behavior in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c07ca7108322a7b342d45a6c7c1e