### PR TITLE
feat(menu/install): skip DB prompt when installed & choose install/update before execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,13 +290,13 @@ sudo "$(command -v lampkitctl)" install-lamp --db-engine auto \
 falling back to `mariadb-server`. Override the choice with `--db-engine mysql`
 or `--db-engine mariadb`.
 
-The installer now inspects each Apache, database, PHP and Certbot package and
-places them into three buckets: missing, upgradable and up‑to‑date. If any are
-missing, the full stack is installed. If only upgrades are available, a concise
-summary is shown and you are asked to confirm the update using
-`apt-get install --only-upgrade`. When everything is up‑to‑date the command
-offers to force a reinstall. All prompts honour `--dry-run` and the apt lock
-handling options.
+When the LAMP components are already present the tool auto-detects the
+installed database engine and skips the engine prompt, showing a concise
+summary of which packages are missing, upgradable or up-to-date. If any are
+missing the full stack is installed. If only upgrades are available you are
+asked to confirm an update using `apt-get install --only-upgrade`. When
+everything is up-to-date the command offers to force a reinstall. All prompts
+honour `--dry-run` and the apt lock handling options.
 
 ### Troubleshooting
 

--- a/lampkitctl/cli.py
+++ b/lampkitctl/cli.py
@@ -141,7 +141,7 @@ def install_lamp(
     preflight.ensure_or_fail(
         checks, interactive=not non_interactive, dry_run=dry_run
     )
-    eng = system_ops.install_lamp_stack(
+    eng = system_ops.install_lamp_stack_full(
         None if db_engine == "auto" else db_engine,
         dry_run=dry_run,
     )

--- a/lampkitctl/db_detect.py
+++ b/lampkitctl/db_detect.py
@@ -8,17 +8,23 @@ from typing import Literal
 logger = logging.getLogger(__name__)
 
 
-def _dpkg_installed(pkg: str) -> bool:
-    """Return True if dpkg reports ``pkg`` as installed."""
+def _pkg_installed(pkg: str) -> bool:
+    """Return ``True`` if ``apt`` reports ``pkg`` as installed."""
+
     try:
         proc = subprocess.run(
-            ["dpkg", "-s", pkg], capture_output=True, text=True
+            ["apt-cache", "policy", pkg], capture_output=True, text=True
         )
     except OSError:
         return False
     if proc.returncode != 0:
         return False
-    return re.search(r"^Status: .* installed", proc.stdout or "", re.MULTILINE) is not None
+    out = proc.stdout or ""
+    m = re.search(r"Installed:\s*(.+)", out)
+    if not m:
+        return False
+    ver = m.group(1).strip()
+    return ver not in {"(none)", "none", "<none>"}
 
 
 _ENGINE_NAMES = {"mysql": "mysql-server", "mariadb": "mariadb-server"}
@@ -30,17 +36,23 @@ def detect_db_engine() -> Literal["mysql", "mariadb"] | None:
     Returns ``"mysql"`` or ``"mariadb"`` when one engine is installed, otherwise
     ``None``. Logs the detection source for observability.
     """
-    mysql_inst = _dpkg_installed(_ENGINE_NAMES["mysql"])
-    mariadb_inst = _dpkg_installed(_ENGINE_NAMES["mariadb"])
+    mysql_inst = _pkg_installed(_ENGINE_NAMES["mysql"])
+    mariadb_inst = _pkg_installed(_ENGINE_NAMES["mariadb"])
 
     if mysql_inst and not mariadb_inst:
-        logger.info("db_engine_autodetect", extra={"engine": "mysql", "source": "dpkg"})
+        logger.info(
+            "db_engine_autodetect", extra={"engine": "mysql", "source": "dpkg"}
+        )
         return "mysql"
     if mariadb_inst and not mysql_inst:
-        logger.info("db_engine_autodetect", extra={"engine": "mariadb", "source": "dpkg"})
+        logger.info(
+            "db_engine_autodetect", extra={"engine": "mariadb", "source": "dpkg"}
+        )
         return "mariadb"
     if mysql_inst and mariadb_inst:
-        logger.info("db_engine_autodetect", extra={"engine": None, "source": "dpkg"})
+        logger.info(
+            "db_engine_autodetect", extra={"engine": None, "source": "dpkg"}
+        )
         return None
 
     try:

--- a/lampkitctl/system_ops.py
+++ b/lampkitctl/system_ops.py
@@ -103,6 +103,39 @@ def ensure_db_ready(retries: int = 5, delay: float = 1.0, dry_run: bool = False)
 
 
 def install_lamp_stack(
+    pkgs: list[str], *, dry_run: bool = False
+) -> None:
+    """Install missing LAMP packages."""
+
+    logger.info(
+        "install_lamp_stack", extra={"packages": pkgs, "dry_run": dry_run}
+    )
+    run_command(
+        ["apt-get", "install", "-y", "--no-install-recommends", *pkgs], dry_run
+    )
+
+
+def update_lamp_stack(upgradable: list[str], *, dry_run: bool = False) -> None:
+    """Upgrade existing LAMP packages."""
+
+    logger.info(
+        "update_lamp_stack", extra={"upgradable": upgradable, "dry_run": dry_run}
+    )
+    run_command(
+        ["apt-get", "install", "-y", "--only-upgrade", *upgradable], dry_run
+    )
+
+
+def reinstall_lamp_stack(pkgs: list[str], *, dry_run: bool = False) -> None:
+    """Reinstall LAMP packages."""
+
+    logger.info(
+        "reinstall_lamp_stack", extra={"packages": pkgs, "dry_run": dry_run}
+    )
+    run_command(["apt-get", "install", "-y", "--reinstall", *pkgs], dry_run)
+
+
+def install_lamp_stack_full(
     preferred_engine: str | None,
     with_php: bool = True,
     with_certbot: bool = True,
@@ -128,7 +161,7 @@ def install_lamp_stack(
     if with_certbot:
         pkgs += CERTBOT_PKGS
     logger.info(
-        "install_lamp_stack",
+        "install_lamp_stack_full",
         extra={"packages": pkgs, "db_engine": eng.name, "dry_run": dry_run},
     )
     install_cmd = ["apt-get", "install", "-y"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ def test_cli_install_lamp(monkeypatch) -> None:
         calls.append(pref)
         return packages.Engine("mariadb", "mariadb-server", "mariadb-client", "mariadb")
 
-    monkeypatch.setattr(cli.system_ops, "install_lamp_stack", fake_install)
+    monkeypatch.setattr(cli.system_ops, "install_lamp_stack_full", fake_install)
     runner = CliRunner()
     result = runner.invoke(
         cli.cli, ["--dry-run", "install-lamp", "--db-engine", "mariadb"], input="n\n"

--- a/tests/test_cli_guards.py
+++ b/tests/test_cli_guards.py
@@ -43,7 +43,7 @@ def test_install_lamp_preflight_pass(monkeypatch):
     monkeypatch.setattr(cli.preflight_locks, "wait_for_lock", lambda *a, **k: preflight_locks.LockInfo(False))
     monkeypatch.setattr(
         cli.system_ops,
-        "install_lamp_stack",
+        "install_lamp_stack_full",
         lambda pref, dry_run=False: packages.Engine("mysql", "mysql-server", "mysql-client", "mysql"),
     )
     runner = CliRunner()

--- a/tests/test_db_autodetect_dpkg.py
+++ b/tests/test_db_autodetect_dpkg.py
@@ -12,12 +12,12 @@ class Proc:
 
 def test_detect_mysql_via_dpkg(monkeypatch):
     def fake_run(cmd, capture_output=True, text=True):
-        if cmd[:2] == ["dpkg", "-s"]:
+        if cmd[:2] == ["apt-cache", "policy"]:
             pkg = cmd[2]
             if pkg == "mysql-server":
-                return Proc("Status: install ok installed\n")
+                return Proc("Installed: 8.0\n")
             if pkg == "mariadb-server":
-                return Proc("Status: deinstall ok not-installed\n", returncode=1)
+                return Proc("Installed: (none)\n")
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -26,12 +26,12 @@ def test_detect_mysql_via_dpkg(monkeypatch):
 
 def test_detect_mariadb_via_dpkg(monkeypatch):
     def fake_run(cmd, capture_output=True, text=True):
-        if cmd[:2] == ["dpkg", "-s"]:
+        if cmd[:2] == ["apt-cache", "policy"]:
             pkg = cmd[2]
             if pkg == "mysql-server":
-                return Proc("Status: deinstall ok not-installed\n", returncode=1)
+                return Proc("Installed: (none)\n")
             if pkg == "mariadb-server":
-                return Proc("Status: install ok installed\n")
+                return Proc("Installed: 10.5\n")
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -40,8 +40,8 @@ def test_detect_mariadb_via_dpkg(monkeypatch):
 
 def test_detect_none_via_dpkg(monkeypatch):
     def fake_run(cmd, capture_output=True, text=True):
-        if cmd[:2] == ["dpkg", "-s"]:
-            return Proc("Status: deinstall ok not-installed\n", returncode=1)
+        if cmd[:2] == ["apt-cache", "policy"]:
+            return Proc("Installed: (none)\n")
         raise FileNotFoundError
 
     monkeypatch.setattr(subprocess, "run", fake_run)

--- a/tests/test_db_autodetect_version.py
+++ b/tests/test_db_autodetect_version.py
@@ -14,8 +14,8 @@ class Proc:
 
 def _fake_run_factory(output: str):
     def fake_run(cmd, capture_output=True, text=True):
-        if cmd[:2] == ["dpkg", "-s"]:
-            return Proc("Status: deinstall ok not-installed\n", returncode=1)
+        if cmd[:2] == ["apt-cache", "policy"]:
+            return Proc("Installed: (none)\n")
         if cmd[:2] == ["mysql", "--version"]:
             return Proc(output)
         raise AssertionError(f"unexpected command: {cmd}")

--- a/tests/test_install_flow_root_pass.py
+++ b/tests/test_install_flow_root_pass.py
@@ -15,7 +15,7 @@ def _setup_common(monkeypatch, calls):
         cli.preflight_locks, "detect_lock", lambda: preflight_locks.LockInfo(False)
     )
     fake_engine = packages.Engine("mysql", "mysql-server", "mysql-client", "mysql")
-    monkeypatch.setattr(system_ops, "install_lamp_stack", lambda *a, **k: fake_engine)
+    monkeypatch.setattr(system_ops, "install_lamp_stack_full", lambda *a, **k: fake_engine)
     monkeypatch.setattr(system_ops, "ensure_db_ready", lambda **k: True)
     monkeypatch.setattr(cli.utils, "setup_logging", lambda *a, **k: None)
 

--- a/tests/test_install_lamp_cli_prompt_flags.py
+++ b/tests/test_install_lamp_cli_prompt_flags.py
@@ -14,7 +14,7 @@ def _setup_common(monkeypatch, calls):
         cli.preflight_locks, "detect_lock", lambda: preflight_locks.LockInfo(False)
     )
     fake_engine = packages.Engine("mysql", "mysql-server", "mysql-client", "mysql")
-    monkeypatch.setattr(system_ops, "install_lamp_stack", lambda *a, **k: fake_engine)
+    monkeypatch.setattr(system_ops, "install_lamp_stack_full", lambda *a, **k: fake_engine)
     monkeypatch.setattr(system_ops, "ensure_db_ready", lambda **k: True)
     monkeypatch.setattr(cli.utils, "setup_logging", lambda *a, **k: None)
 

--- a/tests/test_install_lamp_stack.py
+++ b/tests/test_install_lamp_stack.py
@@ -21,7 +21,7 @@ def test_update_before_detection(monkeypatch):
     monkeypatch.setattr(system_ops, "run_command", fake_run)
     monkeypatch.setattr(system_ops.preflight_locks, "detect_lock", lambda: preflight_locks.LockInfo(False))
 
-    system_ops.install_lamp_stack(None, dry_run=True)
+    system_ops.install_lamp_stack_full(None, dry_run=True)
 
     assert calls[0:2] == ["update", "detect"]
     install_cmd = calls[2]

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -21,7 +21,7 @@ def test_run_menu_routing(monkeypatch):
 
     called = {}
 
-    def fake_install_lamp(db_engine: str, wait_apt_lock: int, dry_run: bool):
+    def fake_install_lamp(db_engine: str, wait_apt_lock: int, dry_run: bool, **kwargs):
         called["engine"] = db_engine
         called["wait"] = wait_apt_lock
         return "mysql"

--- a/tests/test_menu_db_choice.py
+++ b/tests/test_menu_db_choice.py
@@ -9,7 +9,7 @@ def test_menu_db_choice(monkeypatch):
 
     called = {}
 
-    def fake_install_lamp(db_engine: str, wait_apt_lock: int, dry_run: bool):
+    def fake_install_lamp(db_engine: str, wait_apt_lock: int, dry_run: bool, **kwargs):
         called["engine"] = db_engine
         return "mariadb"
 

--- a/tests/test_menu_install_missing_install.py
+++ b/tests/test_menu_install_missing_install.py
@@ -17,10 +17,10 @@ def test_menu_install_missing_install(monkeypatch):
     monkeypatch.setattr(menu.system_ops, "compute_lamp_packages", lambda e: ["mysql-server", "apache2"])
     monkeypatch.setattr(menu.system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
 
-    def fake_install_or_update(engine, dry_run=False, refresh=False):
-        calls.append(["apt-get", "install", "-y", "--no-install-recommends", "mysql-server", "apache2"])
+    def fake_install(pkgs, dry_run=False):
+        calls.append(["apt-get", "install", "-y", "--no-install-recommends", *pkgs])
 
-    monkeypatch.setattr(menu.system_ops, "install_or_update_lamp", fake_install_or_update)
+    monkeypatch.setattr(menu.system_ops, "install_lamp_stack", fake_install)
     monkeypatch.setattr(menu, "_confirm", lambda msg, default=True: True)
 
     menu.install_lamp(db_engine="mysql", wait_apt_lock=0, dry_run=False)

--- a/tests/test_menu_install_updates.py
+++ b/tests/test_menu_install_updates.py
@@ -17,10 +17,10 @@ def test_menu_install_updates(monkeypatch):
     monkeypatch.setattr(menu.system_ops, "compute_lamp_packages", lambda e: ["mysql-server", "apache2"])
     monkeypatch.setattr(menu.system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
 
-    def fake_install_or_update(db_engine, dry_run=False, refresh=False):
-        calls.append(["apt-get", "install", "-y", "--only-upgrade", "apache2"])
+    def fake_update(pkgs, dry_run=False):
+        calls.append(["apt-get", "install", "-y", "--only-upgrade", *pkgs])
 
-    monkeypatch.setattr(menu.system_ops, "install_or_update_lamp", fake_install_or_update)
+    monkeypatch.setattr(menu.system_ops, "update_lamp_stack", fake_update)
     monkeypatch.setattr(menu, "_confirm", lambda msg, default=True: True)
 
     menu.install_lamp(db_engine="mysql", wait_apt_lock=0, dry_run=False)

--- a/tests/test_menu_install_uptodate_noop.py
+++ b/tests/test_menu_install_uptodate_noop.py
@@ -16,7 +16,8 @@ def test_menu_install_uptodate_noop(monkeypatch):
 
     monkeypatch.setattr(menu.system_ops, "compute_lamp_packages", lambda e: ["mysql-server", "apache2"])
     monkeypatch.setattr(menu.system_ops, "run_command", lambda cmd, dry_run: calls.append(cmd))
-    monkeypatch.setattr(menu.system_ops, "install_or_update_lamp", lambda *a, **k: calls.append(["unexpected"]))
+    monkeypatch.setattr(menu.system_ops, "install_lamp_stack", lambda *a, **k: calls.append(["unexpected"]))
+    monkeypatch.setattr(menu.system_ops, "update_lamp_stack", lambda *a, **k: calls.append(["unexpected"]))
     monkeypatch.setattr(menu, "_confirm", lambda msg, default=False: False)
 
     menu.install_lamp(db_engine="mysql", wait_apt_lock=0, dry_run=False)

--- a/tests/test_menu_respects_override.py
+++ b/tests/test_menu_respects_override.py
@@ -12,7 +12,8 @@ def test_menu_respects_db_engine_override(monkeypatch):
     monkeypatch.setattr(menu.system_ops, "detect_db_engine", fail_detect)
     monkeypatch.setattr(menu.system_ops, "compute_lamp_packages", lambda e: [e])
     monkeypatch.setattr(menu.system_ops, "run_command", lambda *a, **k: None)
-    monkeypatch.setattr(menu.system_ops, "install_or_update_lamp", lambda *a, **k: None)
+    monkeypatch.setattr(menu.system_ops, "install_lamp_stack", lambda *a, **k: None)
+    monkeypatch.setattr(menu.system_ops, "update_lamp_stack", lambda *a, **k: None)
 
     monkeypatch.setattr(menu, "detect_pkg_status", lambda pkgs: PkgStatus([], [], pkgs))
     monkeypatch.setattr(menu.preflight, "ensure_or_fail", lambda *a, **k: None)

--- a/tests/test_preflight_root.py
+++ b/tests/test_preflight_root.py
@@ -23,7 +23,7 @@ def test_install_lamp_requires_root(monkeypatch):
     )
     calls = []
     monkeypatch.setattr(
-        cli.system_ops, "install_lamp_stack", lambda *a, **k: calls.append(a)
+        cli.system_ops, "install_lamp_stack_full", lambda *a, **k: calls.append(a)
     )
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["install-lamp"])


### PR DESCRIPTION
## Summary
- auto-detect MySQL/MariaDB via apt-cache and mysql --version
- add install/update/reinstall helpers for LAMP packages
- show package status before install and decide update vs reinstall in menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b61d94d08322b6414355b9d4a5c4