### PR TITLE
feat(menu/install): upgrade core (apache2, DB, php) when already installed; install only when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,13 @@ sudo lampkitctl install-lamp --db-engine mariadb
 sudo lampkitctl install-lamp --db-engine auto --dry-run
 ```
 
+If Apache, PHP and the database server are already installed, the tool offers
+to run a targeted upgrade instead of reinstalling the full stack:
+
+```
+sudo apt upgrade apache2 mysql-server php  # or mariadb-server
+```
+
 By default the installer prompts to set a **database root password**. From the
 interactive menu this prompt is delegated to the CLI so it appears only once.
 For a non-interactive run supply the password via environment variable:

--- a/lampkitctl/packages.py
+++ b/lampkitctl/packages.py
@@ -52,6 +52,28 @@ def refresh_cache(dry_run: bool = False) -> None:
     utils.run_command(["apt-get", "update"], dry_run=dry_run, capture_output=True)
 
 
+def is_installed(pkg: str) -> bool:
+    """Return ``True`` if ``pkg`` is installed via ``dpkg``."""
+
+    try:
+        proc = subprocess.run(
+            ["dpkg-query", "-W", "-f=${Status}", pkg],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False
+    if proc.returncode != 0:
+        return False
+    return proc.stdout.strip() == "install ok installed"
+
+
+def all_installed(pkgs: List[str]) -> bool:
+    """Return ``True`` when all packages in ``pkgs`` are installed."""
+
+    return all(is_installed(p) for p in pkgs)
+
+
 def detect_db_engine(preferred: str | None = None) -> Engine:
     """Detect a suitable database engine package."""
 

--- a/tests/test_menu_install_missing_installs.py
+++ b/tests/test_menu_install_missing_installs.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from lampkitctl import menu
+
+
+def test_menu_install_missing_installs(monkeypatch):
+    sequence = iter(["Install LAMP server"])
+    monkeypatch.setattr(menu, "_select", lambda msg, choices=None: next(sequence))
+    confirms = iter([True, False])
+    monkeypatch.setattr(menu, "_confirm", lambda msg, default=True: next(confirms))
+    monkeypatch.setattr(menu, "detect_installed_db", lambda: "mysql")
+
+    def fake_is_installed(pkg: str) -> bool:
+        return pkg != "php"
+
+    monkeypatch.setattr(menu, "is_installed", fake_is_installed)
+
+    called = {}
+
+    def fake_install_lamp(db_engine, wait_apt_lock, dry_run, autodetected, show_engine):
+        called["install"] = True
+        return "mysql"
+
+    monkeypatch.setattr(menu, "install_lamp", fake_install_lamp)
+    monkeypatch.setattr(menu.system_ops, "upgrade_core_components", lambda *a, **k: called.update({"upgrade": True}))
+
+    menu.run_menu(dry_run=True)
+
+    assert called.get("install")
+    assert "upgrade" not in called

--- a/tests/test_menu_install_switches_to_upgrade.py
+++ b/tests/test_menu_install_switches_to_upgrade.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+from lampkitctl import menu
+
+
+def test_menu_install_switches_to_upgrade(monkeypatch):
+    sequence = iter(["Install LAMP server"])
+    monkeypatch.setattr(menu, "_select", lambda msg, choices=None: next(sequence))
+    confirms = iter([True, True])
+    monkeypatch.setattr(menu, "_confirm", lambda msg, default=True: next(confirms))
+    monkeypatch.setattr(menu, "detect_installed_db", lambda: "mysql")
+    monkeypatch.setattr(menu, "is_installed", lambda pkg: True)
+    monkeypatch.setattr(menu, "maybe_reexec_with_sudo", lambda *a, **k: None)
+    cmds = []
+
+    def fake_run(cmd, dry_run=False, **kwargs):
+        cmds.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(menu.system_ops, "run_command", fake_run)
+    monkeypatch.setattr(
+        menu.system_ops.preflight_locks, "wait_for_lock", lambda t: SimpleNamespace(locked=False)
+    )
+    monkeypatch.setattr(
+        menu.system_ops.preflight_locks, "detect_lock", lambda: SimpleNamespace(locked=False)
+    )
+
+    menu.run_menu(dry_run=True)
+
+    assert ["apt", "upgrade", "-y", "apache2", "mysql-server", "php"] in cmds
+    assert not any(cmd[:2] == ["apt-get", "install"] for cmd in cmds)

--- a/tests/test_upgrade_core_dry_run.py
+++ b/tests/test_upgrade_core_dry_run.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+from lampkitctl import system_ops
+
+
+def test_upgrade_core_dry_run(monkeypatch):
+    cmds = []
+
+    def fake_run(cmd, dry_run=False, **kwargs):
+        cmds.append((cmd, dry_run))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(system_ops, "run_command", fake_run)
+    monkeypatch.setattr(
+        system_ops.preflight_locks, "wait_for_lock", lambda t: SimpleNamespace(locked=False)
+    )
+    monkeypatch.setattr(
+        system_ops.preflight_locks, "detect_lock", lambda: SimpleNamespace(locked=False)
+    )
+
+    system_ops.upgrade_core_components("mysql", dry_run=True, wait_apt_lock=120)
+
+    assert cmds[1][0][:3] == ["apt", "upgrade", "-y"]
+    assert cmds[1][1] is True

--- a/tests/test_upgrade_core_engine_switch.py
+++ b/tests/test_upgrade_core_engine_switch.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+from lampkitctl import system_ops
+
+
+def test_upgrade_core_engine_switch(monkeypatch):
+    cmds = []
+
+    def fake_run(cmd, dry_run=False, **kwargs):
+        cmds.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(system_ops, "run_command", fake_run)
+    monkeypatch.setattr(
+        system_ops.preflight_locks, "wait_for_lock", lambda t: SimpleNamespace(locked=False)
+    )
+    monkeypatch.setattr(
+        system_ops.preflight_locks, "detect_lock", lambda: SimpleNamespace(locked=False)
+    )
+
+    system_ops.upgrade_core_components("mariadb", dry_run=True, wait_apt_lock=120)
+
+    assert ["apt", "upgrade", "-y", "apache2", "mariadb-server", "php"] in cmds
+    assert all("mysql-server" not in cmd for cmd in cmds if isinstance(cmd, list))


### PR DESCRIPTION
## Summary
- detect installed apache2/php/DB packages before running installation
- offer targeted apt upgrade when all components present
- add helper utilities and tests for upgrade vs install logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5bc7716888322bf5d6a576d611f34