### PR TITLE
feat: inline table site picker

### DIFF
--- a/lampkitctl/menu.py
+++ b/lampkitctl/menu.py
@@ -425,7 +425,6 @@ def _choose_site() -> apache_vhosts.VHost | str | None:
     if not sites:
         secho("No sites found", fg="red")
         return None
-    render_sites_table(sites, pad_top=1, pad_bottom=1)
     choices = format_site_choices(sites)
     choices.append({"name": "Custom...", "value": "__custom__"})
     if inquirer:  # pragma: no cover
@@ -433,11 +432,16 @@ def _choose_site() -> apache_vhosts.VHost | str | None:
     else:
         while True:
             print("Select a site")
-            for idx, choice in enumerate(choices, 1):
-                print(f"{idx}) {choice['name']}")
+            numbered: list[dict] = []
+            for choice in choices:
+                if choice.get("disabled"):
+                    print(choice["name"])
+                else:
+                    numbered.append(choice)
+                    print(f"{len(numbered)}) {choice['name']}")
             resp = input("Select: ").strip()
-            if resp.isdigit() and 1 <= int(resp) <= len(choices):
-                sel = choices[int(resp) - 1]["value"]
+            if resp.isdigit() and 1 <= int(resp) <= len(numbered):
+                sel = numbered[int(resp) - 1]["value"]
                 break
     if sel == "__custom__":
         return "custom"

--- a/lampkitctl/utils.py
+++ b/lampkitctl/utils.py
@@ -343,8 +343,11 @@ def render_sites_table(
 def format_site_choices(sites: Iterable[Tuple[str, str]]) -> List[dict]:
     """Return ``InquirerPy``-compatible choices for discovered sites.
 
-    The ``name`` shown to users is ``domain.ljust(width) | path`` while the
-    ``value`` is the ``(domain, path)`` tuple.
+    A table-style layout is produced within the picker itself. The first two
+    entries are a disabled header row (``DOMAIN | PATH``) and a divider
+    matching the column widths. Each subsequent entry represents a site with
+    padded columns to keep alignment. The ``value`` for selectable rows is the
+    ``(domain, path)`` tuple.
     """
 
     sites = list(sites)
@@ -352,9 +355,25 @@ def format_site_choices(sites: Iterable[Tuple[str, str]]) -> List[dict]:
         return []
 
     domain_w = max(len("DOMAIN"), max(len(d) for d, _ in sites))
-    return [
-        {"name": f"{d.ljust(domain_w)} | {p}", "value": (d, p)} for d, p in sites
+    path_w = max(len("PATH"), max(len(p) for _, p in sites))
+
+    header = f"{'DOMAIN'.ljust(domain_w)} | {'PATH'.ljust(path_w)}"
+    sep = f"{'-' * domain_w}-+-{'-' * path_w}"
+
+    choices: List[dict] = [
+        {"name": header, "disabled": True},
+        {"name": sep, "disabled": True},
     ]
+
+    for d, p in sites:
+        choices.append(
+            {
+                "name": f"{d.ljust(domain_w)} | {p.ljust(path_w)}",
+                "value": (d, p),
+            }
+        )
+
+    return choices
 
 
 def render_sites_list(sites: list[tuple[str, str]], *, color: bool = True) -> None:

--- a/tests/test_menu_site_picker_table_preview.py
+++ b/tests/test_menu_site_picker_table_preview.py
@@ -5,7 +5,7 @@ def make_vhost(domain, docroot, ssl=False):
     return apache_vhosts.VHost(domain, docroot, f"/etc/apache2/sites-available/{domain}.conf", ssl)
 
 
-def test_menu_site_picker_table_preview(monkeypatch, capsys):
+def test_menu_site_picker_table_inline(monkeypatch, capsys):
     vhosts = [make_vhost("a.com", "/var/www/a"), make_vhost("b.net", "/var/www/b")]
     monkeypatch.setattr(menu.apache_vhosts, "list_vhosts", lambda: vhosts)
     monkeypatch.setattr(menu, "inquirer", None)
@@ -21,14 +21,13 @@ def test_menu_site_picker_table_preview(monkeypatch, capsys):
     sep = f"{'-' * domain_w}-+-{'-' * path_w}"
 
     lines = out.splitlines()
-    header_idx = lines.index(header)
-    sep_idx = lines.index(sep)
-    prompt_idx = lines.index("Select a site")
-    assert header_idx < prompt_idx
-    assert sep_idx < prompt_idx
+    assert lines[0] == "Select a site"
+    assert lines[1] == header
+    assert lines[2] == sep
 
-    name1 = f"{vhosts[0].domain.ljust(domain_w)} | {vhosts[0].docroot}"
-    name2 = f"{vhosts[1].domain.ljust(domain_w)} | {vhosts[1].docroot}"
-    assert f"1) {name1}" in out
-    assert f"2) {name2}" in out
+    name1 = f"{vhosts[0].domain.ljust(domain_w)} | {vhosts[0].docroot.ljust(path_w)}"
+    name2 = f"{vhosts[1].domain.ljust(domain_w)} | {vhosts[1].docroot.ljust(path_w)}"
+    assert lines[3] == f"1) {name1}"
+    assert lines[4] == f"2) {name2}"
+    assert lines[5] == "3) Custom..."
     assert sel == vhosts[0]


### PR DESCRIPTION
## Summary
- show site choices as a table inside the picker
- keep numbered options clean by skipping disabled header lines
- update tests for inline table layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5c9bbaa988322a41e2becd9960c16