### PR TITLE
Fix InquirerPy site picker crash

### DIFF
--- a/lampkitctl/utils.py
+++ b/lampkitctl/utils.py
@@ -360,9 +360,13 @@ def format_site_choices(sites: Iterable[Tuple[str, str]]) -> List[dict]:
     header = f"{'DOMAIN'.ljust(domain_w)} | {'PATH'.ljust(path_w)}"
     sep = f"{'-' * domain_w}-+-{'-' * path_w}"
 
+    # ``InquirerPy`` 0.3+ requires each choice to define both ``name`` and
+    # ``value``.  The table header and separator are disabled entries and do not
+    # need meaningful values, but we still provide dummy placeholders to avoid
+    # crashes when the picker is rendered with ``InquirerPy``.
     choices: List[dict] = [
-        {"name": header, "disabled": True},
-        {"name": sep, "disabled": True},
+        {"name": header, "value": header, "disabled": True},
+        {"name": sep, "value": sep, "disabled": True},
     ]
 
     for d, p in sites:

--- a/tests/test_site_picker_choices_have_values.py
+++ b/tests/test_site_picker_choices_have_values.py
@@ -1,0 +1,7 @@
+from lampkitctl import utils
+
+
+def test_format_site_choices_all_entries_have_value():
+    sites = [("a.com", "/var/www/a"), ("b.net", "/var/www/b")]
+    choices = utils.format_site_choices(sites)
+    assert all("name" in c and "value" in c for c in choices)


### PR DESCRIPTION
## Summary
- ensure site picker choices always provide a `value` to satisfy InquirerPy
- add regression test verifying picker entries include `name` and `value`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5ccc183988322b52e127ce328021a